### PR TITLE
Canvas Resizing Bug Fix

### DIFF
--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -69,14 +69,14 @@ export default class NodeWrapper extends SelectableObject {
     });
 
     this.nodeLabel = new Konva.Text({
-      x: -NodeWrapper.NodeRadius,
-      y: -NodeWrapper.NodeRadius,
-      width: NodeWrapper.NodeRadius * 2,
-      height: NodeWrapper.NodeRadius * 2,
+      x: (-NodeWrapper.NodeRadius * 2 * 0.75) / 2,
+      y: (-NodeWrapper.NodeRadius * 2 * 0.75) / 2,
+      width: NodeWrapper.NodeRadius * 2 * 0.75,
+      height: NodeWrapper.NodeRadius * 2 * 0.75,
       align: 'center',
       verticalAlign: 'middle',
       text: this._labelText,
-      fontSize: 20,
+      fontSize: 15,
       fill: StateManager.colorScheme.nodeLabelColor,
     });
 
@@ -97,6 +97,44 @@ export default class NodeWrapper extends SelectableObject {
     this.nodeGroup.on('dragend', (ev) => this.onDragEnd.call(this, ev));
   }
 
+  public adjustFontSize() {
+    const maxTextWidth = NodeWrapper.NodeRadius * 2 * 0.75; // 75% of the diameter (inner circle is 80% of diameter)
+    let fontSize = this.nodeLabel.fontSize();
+    
+    const tempText = new Konva.Text({
+      text: this._labelText,
+      fontSize: fontSize,
+    });
+  
+    // measure text width with current font size
+    let textWidth = tempText.getClientRect().width;
+
+    if (textWidth > maxTextWidth && fontSize > 10) 
+    {
+      while (textWidth > maxTextWidth && fontSize > 10) 
+      { // minimum font size is 10
+        fontSize -= 1; // decrement font size
+        tempText.fontSize(fontSize); // update tempText font size
+        textWidth = tempText.getClientRect().width; // remeasure text width with new font size
+      }
+    } 
+    else if (textWidth < maxTextWidth && fontSize < 15) 
+    {
+      // Increase font size until the text fits within the maximum width
+      while (textWidth < maxTextWidth && fontSize < 15) 
+      { 
+        fontSize += 1; // increment font size
+        tempText.fontSize(fontSize); 
+        textWidth = tempText.getClientRect().width; 
+      }
+    }
+
+    this.nodeLabel.fontSize(fontSize);
+    this.nodeLabel.wrap('word');
+    this.nodeLabel.align('center');
+    this.nodeLabel.verticalAlign('middle');
+  }
+  
   public onClick(ev: Konva.KonvaEventObject<MouseEvent>) {
     if (StateManager.currentTool === Tool.Select) {
       // If shift isn't being held, then clear all previous selection
@@ -250,6 +288,7 @@ export default class NodeWrapper extends SelectableObject {
   public set labelText(value: string) {
     this._labelText = value;
     this.nodeLabel.text(this._labelText);
+    this.adjustFontSize();
   }
 
   public updateColorScheme() {

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -98,6 +98,15 @@ export default class StateManager {
         this._stage.add(this._nodeLayer);
 
         addEventListener('keydown', this.onKeyDown);
+        addEventListener('resize', this.handleResize);
+    }
+    //handles resizing the canvas when the window is resized using an event listener
+    private static handleResize() {
+        if (StateManager._stage) {
+            StateManager._stage.width(window.innerWidth);
+            StateManager._stage.height(window.innerHeight);
+            StateManager._stage.draw();
+        }
     }
 
     public static get currentTool() {


### PR DESCRIPTION
Fixed a bug where the canvas did not resize when window size was changed. A listener was added to check when the window size is changed and a function is then used to update the canvas size accordingly. In the future, a removeEventListener call for cleanup may be smart to mitigate potential memory leaks, but I was unsure of where I should place one and did not see one for the event listener that was already there.