### PR TITLE
Warning and error message boxes

### DIFF
--- a/src/components/InformationBox.tsx
+++ b/src/components/InformationBox.tsx
@@ -1,0 +1,82 @@
+import { BsXCircleFill, BsExclamationTriangleFill, BsEyeFill, BsInfoCircleFill, BsChevronRight } from 'react-icons/bs';
+
+export enum InformationBoxType {
+    Warning,
+    Error
+}
+
+interface InformationBoxProps {
+    infoBoxType: InformationBoxType,
+}
+
+function AdditionalInfoButton() {
+    return (
+        <button className="rounded-full px-2 py-0 mr-2 block bg-red-600 text-white">
+            <div className='flex flex-row items-center place-content-center mx-0'>
+                <BsInfoCircleFill className='mr-1' />
+                Learn more
+                <BsChevronRight className='ml-1' />
+            </div>
+        </button>
+    );
+}
+
+function ErrorBox(props: React.PropsWithChildren) {
+    return (
+        <>
+            <div className={`bg-red-100 dark:bg-red-900 border-2 border-red-500 rounded-lg mb-2`}>
+                <div className='flex flex-row text-left items-center place-content-start p-2'>
+                    <BsXCircleFill className='shrink-0 mr-2 text-red-600 text-lg' />
+                    <div>
+                        {props.children}
+                    </div>
+                    {/* Use for indicating that there is more detail available -
+                    not necessary at this stage */}
+                    {/* <BsChevronRight className='shrink-0 ml-auto' /> */}
+                </div>
+            </div>
+        </>
+    );
+}
+
+function WarningBox(props: React.PropsWithChildren) {
+    return (
+        <>
+            <div className={`bg-amber-100 dark:bg-amber-900 border-2 border-yellow-500 rounded-lg mb-2`}>
+                <div className='flex flex-row text-left items-center place-content-start p-2'>
+                    <BsExclamationTriangleFill className='shrink-0 grow-0 mr-2 text-yellow-500 text-lg' />
+                    <div>
+                        {props.children}
+                    </div>
+                    {/* Use for indicating that there is more detail available -
+                    not necessary at this stage */}
+                    {/* <BsChevronRight className='shrink-0 ml-auto' /> */}
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default function InformationBox(props: React.PropsWithChildren<InformationBoxProps>) {
+    switch (props.infoBoxType) {
+        case InformationBoxType.Warning:
+            return (
+                <WarningBox>
+                    <div>{props.children}</div>
+                    {/* <div>
+                        <AdditionalInfoButton />
+                    </div> */}
+                </WarningBox>
+            );
+        case InformationBoxType.Error:
+            return (
+                <ErrorBox>
+                    <div>{props.children}</div>
+                    {/* <div>
+                        <AdditionalInfoButton />
+                    </div> */}
+                </ErrorBox>
+            );
+    }
+
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import ModalWindow, { ClosableModalWindow } from './components/ModalWindow';
 import ConfigureAutomatonWindow from './components/ConfigureAutomatonWindow';
 import { BsGearFill, BsMoonFill, BsCheck2Circle } from 'react-icons/bs';
 import TestStringWindow from './components/TestStringWindow';
+import InformationBox, { InformationBoxType } from './components/InformationBox';
 
 function App() {
     const [currentTool, setCurrentTool] = useState(Tool.States);
@@ -83,6 +84,36 @@ function App() {
             startNode={startNode}
             setStartNode={setStartNode}
         />
+
+        {/* Some example error message boxes */}
+        <InformationBox infoBoxType={InformationBoxType.Error}>
+            State "q0" has multiple transitions for token "a"
+        </InformationBox>
+
+        <InformationBox infoBoxType={InformationBoxType.Error}>
+            State "q0" has no transition for token "b"
+        </InformationBox>
+
+        <InformationBox infoBoxType={InformationBoxType.Error}>
+            Transitions on empty string (ε) not allowed in DFA
+        </InformationBox>
+
+        <InformationBox infoBoxType={InformationBoxType.Error}>
+            Alphabet needs at least one token
+        </InformationBox>
+
+        <InformationBox infoBoxType={InformationBoxType.Error}>
+            Token "c" is repeated in alphabet
+        </InformationBox>
+
+        <InformationBox infoBoxType={InformationBoxType.Warning}>
+            State "q3" is inaccessible
+        </InformationBox>
+
+        <InformationBox infoBoxType={InformationBoxType.Warning}>
+            Accept state "q4" is inaccessible; automaton will always reject
+        </InformationBox>
+        
         <div className="flex flex-col items-center mt-4">
             <button
                 className="rounded-full p-2 m-1 mx-2 block bg-amber-500 text-white text-center"


### PR DESCRIPTION
This pull request adds message box components suitable for displaying automaton warnings and errors:
<img width="449" alt="image" src="https://github.com/AutomatonBuilderGUI/AutomatonBuilderGUI/assets/9957987/7cb170ae-89e7-4cdc-8812-a0e7fc0b55b5">

<img width="449" alt="image" src="https://github.com/AutomatonBuilderGUI/AutomatonBuilderGUI/assets/9957987/3daa310d-5f94-4b89-847f-f4cdcac2ed18">

Currently, there is no actual functionality to them, as you can see in `index.tsx` - the text is hand-written. Once we are satisfied with the design, and as `automaton-ts` is incorporated more into the software, the boxes can be generated from the output of the library.

Things that I'd still like to add to support future features, but am not quite sure how to incorporate yet:
- A "learn more" button. This would eventually display more details about the error and steps to fix it.
- A "move to location of error" button. This would eventually move the view of the state diagram so that it focuses on the state or transition where the error is.