### PR TITLE
the delete method was removing all non-selected objects

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -346,12 +346,11 @@ export default class StateManager {
                 }
             });
         });
-
         // Keep transitions that aren't in the selected objects, AND aren't dependent on selected objects
-        StateManager._transitionWrappers = StateManager._transitionWrappers.filter((i) => StateManager._selectedObjects.includes(i) && !transitionsDependentOnDeletedNodes.includes(i));
+        StateManager._transitionWrappers = StateManager._transitionWrappers.filter((i) => !StateManager._selectedObjects.includes(i) && !transitionsDependentOnDeletedNodes.includes(i));
 
         // Next, delete all selected nodes
-        StateManager._nodeWrappers = StateManager._nodeWrappers.filter((i) => StateManager._selectedObjects.includes(i));
+        StateManager._nodeWrappers = StateManager._nodeWrappers.filter((i) => !StateManager._selectedObjects.includes(i));
 
         StateManager._selectedObjects.forEach((obj) => obj.deleteKonvaObjects());
         transitionsDependentOnDeletedNodes.forEach((obj) => obj.deleteKonvaObjects());


### PR DESCRIPTION
The deleteAllSelectedObjects method's filters were inverted, causing them to remove all transitions and nodes that weren't selected from _transitionWrappers and _nodeWrappers instead of removing all transitions and nodes that were selected, leading to a variety of buggy behavior. I inverted the selection so that it now correctly removes the selected transitions and nodes