### PR TITLE
Dark mode grid too bright fix

### DIFF
--- a/src/ColorSchemes.tsx
+++ b/src/ColorSchemes.tsx
@@ -20,6 +20,8 @@ export const LightColorScheme = {
     transitionSelectedArrowColor: 'red',
     transitionArrowColor: 'black',
     transitionLabelColor: 'black',
+
+    gridColor: "lightgrey",
 };
 
 export const DarkColorScheme = {
@@ -44,6 +46,8 @@ export const DarkColorScheme = {
     transitionSelectedArrowColor: 'red',
     transitionArrowColor: '#E0E0E0',
     transitionLabelColor: 'white',
+
+    gridColor: "#303030",
 };
 
 export interface ColorScheme {
@@ -68,4 +72,6 @@ export interface ColorScheme {
     transitionSelectedArrowColor: string,
     transitionArrowColor: string,
     transitionLabelColor: string,
+
+    gridColor: string,
 }

--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -293,7 +293,7 @@ export default class NodeWrapper extends SelectableObject {
 
   public updateColorScheme() {
     this.nodeBackground.fill(StateManager.colorScheme.nodeFill);
-
+    
     
     this.nodeBackground.stroke(StateManager.colorScheme.nodeStrokeColor);
     this.nodeAcceptCircle.stroke(StateManager.colorScheme.nodeAcceptStrokeColor);

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -132,7 +132,7 @@ export default class StateManager {
         for(let i = 0; i < verticalLineNum; i++){
             let line = new Konva.Line({
                 points: [i * gridCellSize, 0, i * gridCellSize,(horizontalLineNum-1)*gridCellSize],
-                stroke: 'grey',
+                stroke: this.colorScheme.gridColor,
                 strokeWidth: 1,
             });
             gridLayer.add(line);
@@ -141,7 +141,7 @@ export default class StateManager {
         for(let j = 0; j < horizontalLineNum; j++){
             let line = new Konva.Line({
                 points: [0, j * gridCellSize, (verticalLineNum-1)*gridCellSize, j * gridCellSize],
-                stroke: 'grey',
+                stroke: this.colorScheme.gridColor,
                 strokeWidth: 1,
             });
             gridLayer.add(line);
@@ -512,6 +512,14 @@ export default class StateManager {
 
         this._tentConnectionLine.fill(this.colorScheme.tentativeTransitionArrowColor);
         this._tentConnectionLine.stroke(this.colorScheme.tentativeTransitionArrowColor);
+
+        const gridLayer = StateManager._stage.findOne('.gridLayer');
+        if(gridLayer){
+            gridLayer.destroy() ;
+        }
+        StateManager.drawGrid();
+
+        StateManager._stage.draw();
     }
 
     public static get useDarkMode() {

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -132,7 +132,7 @@ export default class StateManager {
         for(let i = 0; i < verticalLineNum; i++){
             let line = new Konva.Line({
                 points: [i * gridCellSize, 0, i * gridCellSize,(horizontalLineNum-1)*gridCellSize],
-                stroke: 'lightgrey',
+                stroke: 'grey',
                 strokeWidth: 1,
             });
             gridLayer.add(line);
@@ -141,7 +141,7 @@ export default class StateManager {
         for(let j = 0; j < horizontalLineNum; j++){
             let line = new Konva.Line({
                 points: [0, j * gridCellSize, (verticalLineNum-1)*gridCellSize, j * gridCellSize],
-                stroke: 'lightgrey',
+                stroke: 'grey',
                 strokeWidth: 1,
             });
             gridLayer.add(line);


### PR DESCRIPTION
Fix the issue of the dark mode grid being too bright. Grid color can now be individually set for light mode and dark mode.