### PR TITLE
State label warning now works

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -385,6 +385,13 @@ export default class StateManager {
         StateManager._stage.position(newPos);
         StateManager._stage.batchDraw();
     }
+
+    public static areAllLabelsUnique(): boolean {
+        const labels = StateManager._nodeWrappers.map(node => node.labelText);
+        const uniqueLabels = new Set(labels);
+        return labels.length === uniqueLabels.size;
+    }
+
     
     public static set alphabet(newAlphabet: Array<TokenWrapper>) {
         const oldAlphabet = StateManager._alphabet;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ function App() {
     const [currentTool, setCurrentTool] = useState(Tool.States);
     const [selectedObjects, setSelectedObjects] = useState(new Array<SelectableObject>());
     const [startNode, setStartNode] = useState(StateManager.startNode);
+    const [isLabelUnique, setIsLabelUnique] = useState(true);
 
     // Switch current tool when keys pressed
     useEffect(() => {
@@ -57,6 +58,11 @@ function App() {
         StateManager.startNode = startNode;
     }, [startNode]);
 
+    useEffect(() => {
+        const unique = StateManager.areAllLabelsUnique();
+        setIsLabelUnique(unique);
+    }, [selectedObjects]);
+
 
     // Config window
     const [configWindowOpen, setConfigWindowOpen] = useState(false);
@@ -84,6 +90,11 @@ function App() {
             startNode={startNode}
             setStartNode={setStartNode}
         />
+        {!isLabelUnique && (
+            <InformationBox infoBoxType={InformationBoxType.Error}>
+                Duplicate state labels detected. Each state must have a unique label.
+            </InformationBox>
+        )}
 
         {/* Some example error message boxes */}
         <InformationBox infoBoxType={InformationBoxType.Error}>


### PR DESCRIPTION
State label warning for states with duplicate names now works properly, state additions and deletions do not cause incorrect error messages