### PR TITLE
Tokens have a max length of one char and an error message appears if a token string is empty

### DIFF
--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -21,7 +21,7 @@ function ListItem_TokenEditor(props: React.PropsWithChildren<ListItem_TokenEdito
         <CoreListItem>
             <div className="flex flex-row">
                 <div className="flex-1 grow float-left">
-                    <input className="focus:outline-none bg-transparent" type="text" placeholder="Token symbol" value={tokenSymbol} onChange={e => setTokenSymbol(e.target.value)}></input>
+                    <input className="focus:outline-none bg-transparent" type="text" minLength={1} maxLength={1} placeholder="Token symbol" value={tokenSymbol} onChange={e => setTokenSymbol(e.target.value)}></input>
                 </div>
                 <button className="flex-0 float-right px-2 block text-center text-red-500 align-middle" onClick={() => props.removeFunc(tw)}>
                     <BsXCircleFill />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ function App() {
     const [currentTool, setCurrentTool] = useState(Tool.States);
     const [selectedObjects, setSelectedObjects] = useState(new Array<SelectableObject>());
     const [startNode, setStartNode] = useState(StateManager.startNode);
-
+  
     // Switch current tool when keys pressed
     useEffect(() => {
         StateManager.setSelectedObjects = setSelectedObjects;
@@ -57,6 +57,8 @@ function App() {
         StateManager.startNode = startNode;
     }, [startNode]);
 
+    const emptyStringToken = StateManager.alphabet.some(token => token.symbol.trim() === '');
+
 
     // Config window
     const [configWindowOpen, setConfigWindowOpen] = useState(false);
@@ -84,6 +86,12 @@ function App() {
             startNode={startNode}
             setStartNode={setStartNode}
         />
+
+        {emptyStringToken && (
+            <InformationBox infoBoxType={InformationBoxType.Error}>
+                Invalid token: Empty string detected.
+            </InformationBox>
+        )}
 
         {/* Some example error message boxes */}
         <InformationBox infoBoxType={InformationBoxType.Error}>


### PR DESCRIPTION
When inputting tokens the user is now restricted from entering more than one character per token. Additionally, if a user closes the window with a token that is just an empty string, an error message is displayed.