### PR TITLE
Test String warnings converted to information boxes

### DIFF
--- a/src/components/InformationBox.tsx
+++ b/src/components/InformationBox.tsx
@@ -1,8 +1,9 @@
-import { BsXCircleFill, BsExclamationTriangleFill, BsEyeFill, BsInfoCircleFill, BsChevronRight } from 'react-icons/bs';
+import { BsXCircleFill, BsExclamationTriangleFill, BsEyeFill, BsInfoCircleFill, BsChevronRight, BsCheckCircle } from 'react-icons/bs';
 
 export enum InformationBoxType {
     Warning,
-    Error
+    Error,
+    Success
 }
 
 interface InformationBoxProps {
@@ -57,6 +58,24 @@ function WarningBox(props: React.PropsWithChildren) {
     );
 }
 
+function SuccessBox(props: React.PropsWithChildren) {
+    return (
+        <>
+            <div className={`bg-green-100 dark:bg-green-900 border-2 border-green-500 rounded-lg mb-2`}>
+                <div className='flex flex-row text-left items-center place-content-start p-2'>
+                    <BsCheckCircle className='shrink-0 grow-0 mr-2 text-green-500 text-lg' />
+                    <div>
+                        {props.children}
+                    </div>
+                    {/* Use for indicating that there is more detail available -
+                    not necessary at this stage */}
+                    {/* <BsChevronRight className='shrink-0 ml-auto' /> */}
+                </div>
+            </div>
+        </>
+    );
+}
+
 export default function InformationBox(props: React.PropsWithChildren<InformationBoxProps>) {
     switch (props.infoBoxType) {
         case InformationBoxType.Warning:
@@ -76,6 +95,15 @@ export default function InformationBox(props: React.PropsWithChildren<Informatio
                         <AdditionalInfoButton />
                     </div> */}
                 </ErrorBox>
+            );
+        case InformationBoxType.Success:
+            return (
+                <SuccessBox>
+                    <div>{props.children}</div>
+                    {/* <div>
+                        <AdditionalInfoButton />
+                    </div> */}
+                </SuccessBox>
             );
     }
 

--- a/src/components/TestStringWindow.tsx
+++ b/src/components/TestStringWindow.tsx
@@ -1,6 +1,7 @@
 import { SetStateAction, useState } from "react";
 import { testStringOnAutomata } from "./TestStringOnAutomata";
 import { BsFillClipboardCheckFill } from "react-icons/bs";
+import InformationBox, { InformationBoxType } from './InformationBox';
 import DFA from 'automaton-kit/lib/dfa/DFA';
 import DFATransition from 'automaton-kit/lib/dfa/DFATransition';
 import DFAState from 'automaton-kit/lib/dfa/DFAState';
@@ -9,15 +10,29 @@ import StateManager from "../StateManager";
 export default function TestStringWindow() {
     const [testString, setTestString] = useState('');
     const [result, setResult] = useState('');
+    const [isError, setIsError] = useState(false);
+
+    const errorMessages = [
+        'Invalid DFA',
+        'Invalid Input Tokens',
+        'Empty string not allowed',
+    ];
 
     const handleTestString = () => {
         const testResult = testStringOnAutomata(testString);
-        setResult(testResult);
+        if (errorMessages.includes(testResult)) {
+            setResult(testResult);
+            setIsError(true); // Set as error
+        } else {
+            setResult(testResult);
+            setIsError(false);
+        }
     };
 
     const handleChange = (e: { target: { value: SetStateAction<string>; }; }) => {
         setTestString(e.target.value);
         setResult(''); // Clear the result when the test string changes
+        setIsError(false);
     };
 
     return (
@@ -28,7 +43,7 @@ export default function TestStringWindow() {
                     type="text"
                     placeholder="Enter string to test"
                     value={testString}
-                    onChange={handleChange} // Updated to use the new handleChange function
+                    onChange={handleChange}
                 />
                 <button
                     className="ml-2 px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 focus:outline-none focus:bg-green-700"
@@ -37,8 +52,16 @@ export default function TestStringWindow() {
                     <BsFillClipboardCheckFill />
                 </button>
             </div>
-            {result && <div className="mt-4 text-lg font-semibold">{`Result: ${result}`}</div>}
-            <div className="flex-1"></div> {/* This div creates extra space at the bottom */}
+            {result && isError && (
+                <InformationBox infoBoxType={InformationBoxType.Error}>
+                    {result}
+                </InformationBox>
+            )}
+            {result && !isError && (
+                <InformationBox infoBoxType={InformationBoxType.Success}>
+                    {result}
+                </InformationBox>
+            )}
         </div>
     );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,8 @@ import ConfigureAutomatonWindow from './components/ConfigureAutomatonWindow';
 import { BsGearFill, BsMoonFill, BsCheck2Circle } from 'react-icons/bs';
 import TestStringWindow from './components/TestStringWindow';
 import InformationBox, { InformationBoxType } from './components/InformationBox';
+import { testStringOnAutomata } from './components/TestStringOnAutomata';
+import {  } from './components/TestStringWindow';
 
 function App() {
     const [currentTool, setCurrentTool] = useState(Tool.States);
@@ -72,6 +74,7 @@ function App() {
     }, [startNode]);
 
     const emptyStringToken = StateManager.alphabet.some(token => token.symbol.trim() === '');
+    const isAutomatonValid = 
 
     useEffect(() => {
         const unique = StateManager.areAllLabelsUnique();
@@ -99,16 +102,6 @@ function App() {
                             startNode={startNode}
                             setStartNode={setStartNode}
                         />
-                        {!isLabelUnique && (
-                            <InformationBox infoBoxType={InformationBoxType.Error}>
-                                Duplicate state labels detected. Each state must have a unique label.
-                            </InformationBox>
-                        )}
-                        {emptyStringToken && (
-                            <InformationBox infoBoxType={InformationBoxType.Error}>
-                                Invalid token: Empty string detected.
-                            </InformationBox>
-                        )}
 
                         {/* Example error message boxes commented out */}
                         {/*
@@ -136,7 +129,17 @@ function App() {
                         */}
 
                         <TestStringWindow />
-
+                        {!isLabelUnique && (
+                            <InformationBox infoBoxType={InformationBoxType.Error}>
+                                Duplicate state labels detected. Each state must have a unique label.
+                            </InformationBox>
+                        )}
+                        {emptyStringToken && (
+                            <InformationBox infoBoxType={InformationBoxType.Error}>
+                                Invalid token: Empty string detected.
+                            </InformationBox>
+                        )}
+                        
                         <div className="flex flex-col items-center mt-4">
                             <button
                                 className="rounded-full p-2 m-1 mx-2 block bg-amber-500 text-white text-center"


### PR DESCRIPTION
Early implementation of converting dfa runner warnings to be stylized like our error information boxes. Errors were moved below the string testing button so errors are located in the same location. New success information box added. At this point the success information box appears either if string is accepted or rejected