### PR TITLE
Add undo/redo

### DIFF
--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -238,6 +238,8 @@ export default class NodeWrapper extends SelectableObject {
           obj.enableDragDropShadow();
         }
       });
+
+      StateManager.startDragStatesOperation(this.lastPos);
     }
   }
 
@@ -263,6 +265,10 @@ export default class NodeWrapper extends SelectableObject {
     }
   }
 
+  public setPosition(position: Vector2d) {
+    this.nodeGroup.position(position);
+  }
+
   public onDragEnd() {
     if (StateManager.currentTool === Tool.States) {
     } 
@@ -277,7 +283,7 @@ export default class NodeWrapper extends SelectableObject {
         let snappedY = Math.round(nodePos.y / gridCellSize) * gridCellSize;
 
         // Adjust the snapped position by the scale to get the final position on the stage
-        this.nodeGroup.position({
+        this.setPosition({
             x: snappedX,
             y: snappedY
         });
@@ -303,6 +309,8 @@ export default class NodeWrapper extends SelectableObject {
                 obj.disableShadowEffects();
             }
         });
+
+        StateManager.completeDragStatesOperation(this.nodeGroup.position());
     }
 }
 

--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -41,12 +41,13 @@ export default class NodeWrapper extends SelectableObject {
     }
   }
 
-  constructor(x: number, y: number, label: string | null = null, isAcceptState: boolean | null = null, id: string | null = null) {
+  constructor(label: string, id: string | null = null) {
     super();
     this._id = id ?? uuidv4();
+    this._labelText = label;
+  }
 
-    this._labelText = label ?? `q${StateManager._nextStateId++}`; // This becomes the label;
-
+  public createKonvaObjects(x: number, y: number) {
     this.nodeGroup = new Konva.Group({ x: x, y: y });
 
     // create our shape

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -491,6 +491,49 @@ export default class StateManager {
         UndoRedoManager.pushAction(addTransitionAction);
     }
 
+    public static addToken() {
+        // TODO: logic for removing tokens needs to be modified - right now
+        // it looks like it does some checks that we may no longer want, now
+        // that we have undo/redo!
+        const newToken = new TokenWrapper();
+        let addTokenForward = (data: AddTokenActionData) => {
+            StateManager._alphabet.push(data.token);
+        };
+        let addTokenBackward = (data: AddTokenActionData) => {
+            StateManager._alphabet = StateManager._alphabet.filter(i => i !== data.token);
+        };
+
+        let addTokenAction = new Action(
+            "addToken",
+            "Add Token",
+            addTokenForward,
+            addTokenBackward,
+            { 'token': newToken }
+        );
+        UndoRedoManager.pushAction(addTokenAction);
+    }
+
+    public static setTokenSymbol(token: TokenWrapper, newSymbol: string) {
+        let oldSymbol = token.symbol;
+
+        let setTokenSymbolForward = (data: SetTokenSymbolActionData) => {
+            data.token.symbol = data.newSymbol;
+        };
+
+        let setTokenSymbolBackward = (data: SetTokenSymbolActionData) => {
+            data.token.symbol = data.oldSymbol;
+        };
+
+        let setTokenSymbolAction = new Action(
+            "setTokenSymbol",
+            `Rename Token "${oldSymbol}" To "${newSymbol}"`,
+            setTokenSymbolForward,
+            setTokenSymbolBackward,
+            {'oldSymbol': oldSymbol, 'newSymbol': newSymbol, 'token': token}
+        );
+        UndoRedoManager.pushAction(setTokenSymbolAction);
+    }
+
     public static setTransitionAcceptsToken(transition: TransitionWrapper, token: TokenWrapper) {
         let hadTokenBefore = transition.hasToken(token);
         let setTransitionAcceptsTokenForward = (data: SetTransitionAcceptsTokenData) => {
@@ -550,7 +593,7 @@ export default class StateManager {
 
         let setTransitionAcceptsEpsilonBackward = (data: SetTransitionAcceptsTokenData) => {
             data.transition.isEpsilonTransition = hadEpsilonBefore;
-        }
+        };
         let setTransitionAcceptsTokenAction = new Action(
             "setTransitionAcceptsEpsilon",
             `Use ε For Transition "${transition.sourceNode.labelText}" To "${transition.destNode.labelText}"`,
@@ -1056,5 +1099,15 @@ class AddTransitionActionData extends ActionData {
 
 class SetTransitionAcceptsTokenData extends ActionData {
     public transition: TransitionWrapper;
+    public token: TokenWrapper;
+}
+
+class AddTokenActionData extends ActionData {
+    public token: TokenWrapper;
+}
+
+class SetTokenSymbolActionData extends ActionData {
+    public oldSymbol: string;
+    public newSymbol: string;
     public token: TokenWrapper;
 }

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -311,6 +311,26 @@ export default class StateManager {
         UndoRedoManager.pushAction(setNodeNameAction);
     }
 
+    public static setNodeIsAccept(nodeWrapper: NodeWrapper, isAccept: boolean) {
+        let oldValue = nodeWrapper.isAcceptNode
+
+        let setNodeIsAcceptForward = (data: SetNodeIsAcceptActionData) => {
+            data.nodeWrapper.isAcceptNode = data.newValue;
+        };
+
+        let setNodeIsAcceptBackward = (data: SetNodeIsAcceptActionData) => {
+            data.nodeWrapper.isAcceptNode = data.oldValue;
+        };
+
+        let setNodeIsAcceptAction = new Action(
+            "setNodeIsAccept",
+            setNodeIsAcceptForward,
+            setNodeIsAcceptBackward,
+            {'oldValue': oldValue, 'newValue': isAccept, 'nodeWrapper': nodeWrapper}
+        );
+        UndoRedoManager.pushAction(setNodeIsAcceptAction);
+    }
+
 
 
     public static addTransition(transition: TransitionWrapper) {
@@ -877,5 +897,11 @@ class MoveStatesActionData extends ActionData {
 class SetNodeNameActionData extends ActionData {
     public oldName: string;
     public newName: string;
+    public nodeWrapper: NodeWrapper;
+}
+
+class SetNodeIsAcceptActionData extends ActionData {
+    public oldValue: boolean;
+    public newValue: boolean;
     public nodeWrapper: NodeWrapper;
 }

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -491,6 +491,55 @@ export default class StateManager {
         UndoRedoManager.pushAction(addTransitionAction);
     }
 
+    public static setTransitionAcceptsToken(transition: TransitionWrapper, token: TokenWrapper) {
+        let hadTokenBefore = transition.hasToken(token);
+        let setTransitionAcceptsTokenForward = (data: SetTransitionAcceptsTokenData) => {
+            data.transition.addToken(data.token);
+        };
+
+        let setTransitionAcceptsTokenBackward = (data: SetTransitionAcceptsTokenData) => {
+            if (hadTokenBefore) {
+                data.transition.addToken(data.token);
+            }
+            else {
+                data.transition.removeToken(data.token);
+            }
+        };
+
+        let setTransitionAcceptsTokenAction = new Action(
+            "setTransitionAcceptsToken",
+            `Use Token "${token.symbol}" For Transition "${transition.sourceNode.labelText}" To "${transition.destNode.labelText}"`,
+            setTransitionAcceptsTokenForward,
+            setTransitionAcceptsTokenBackward,
+            { 'transition': transition, 'token': token }
+        );
+        UndoRedoManager.pushAction(setTransitionAcceptsTokenAction);
+    }
+
+    public static setTransitionDoesntAcceptToken(transition: TransitionWrapper, token: TokenWrapper) {
+        let hadTokenBefore = transition.hasToken(token);
+        let setTransitionDoesntAcceptTokenForward = (data: SetTransitionAcceptsTokenData) => {
+            data.transition.removeToken(data.token);
+        };
+
+        let setTransitionDoesntAcceptTokenBackward = (data: SetTransitionAcceptsTokenData) => {
+            if (hadTokenBefore) {
+                data.transition.addToken(data.token);
+            }
+            else {
+                data.transition.removeToken(data.token);
+            }
+        };
+
+        let setTransitionDoesntAcceptTokenAction = new Action(
+            "setTransitionDoesntAcceptToken",
+            `Don't Use Token "${token.symbol}" For Transition "${transition.sourceNode.labelText}" To "${transition.destNode.labelText}"`,
+            setTransitionDoesntAcceptTokenForward,
+            setTransitionDoesntAcceptTokenBackward,
+            { 'transition': transition, 'token': token }
+        );
+        UndoRedoManager.pushAction(setTransitionDoesntAcceptTokenAction);
+    }
 
     public static get tentativeTransitionInProgress() {
         return StateManager._tentativeTransitionSource !== null;
@@ -963,4 +1012,9 @@ class SetNodeIsStartActionData extends ActionData {
 
 class AddTransitionActionData extends ActionData {
     public transition: TransitionWrapper;
+}
+
+class SetTransitionAcceptsTokenData extends ActionData {
+    public transition: TransitionWrapper;
+    public token: TokenWrapper;
 }

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -306,10 +306,14 @@ export default class StateManager {
             });
 
             data.transitions.forEach(transition => {
+                transition.deselect();
                 transition.konvaGroup.remove();
             });
 
             StateManager.updateTransitions();
+
+            // Disable the node's selected appearance
+            data.node.deselect();
 
             // Remove the node itself
             StateManager._nodeWrappers = StateManager._nodeWrappers.filter(node => {
@@ -556,6 +560,7 @@ export default class StateManager {
         let removeTransitionForward = (data: RemoveTransitionActionData) => {
             StateManager._transitionWrappers = StateManager._transitionWrappers.filter(otherTransition => otherTransition !== data.transition);
 
+            data.transition.deselect();
             data.transition.konvaGroup.remove();
             StateManager.updateTransitions();
         };

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -600,6 +600,29 @@ export default class StateManager {
         UndoRedoManager.pushAction(addTokenAction);
     }
 
+    public static removeToken(token: TokenWrapper) {
+        let transitionsUsingToken = StateManager._transitionWrappers.filter(trans => trans.hasToken(token));
+
+        let removeTokenForward = (data: RemoveTokenActionData) => {
+            StateManager._alphabet = StateManager._alphabet.filter(i => i !== data.token);
+            transitionsUsingToken.forEach(trans => trans.removeToken(token));
+        };
+
+        let removeTokenBackward = (data: RemoveTokenActionData) => {
+            StateManager._alphabet.push(data.token);
+            transitionsUsingToken.forEach(trans => trans.addToken(token));
+        };
+
+        let removeTokenAction = new Action(
+            "removeToken",
+            `Remove Token "${token.symbol}"`,
+            removeTokenForward,
+            removeTokenBackward,
+            { 'token': token, 'transitionsUsingToken': transitionsUsingToken }
+        );
+        UndoRedoManager.pushAction(removeTokenAction);
+    }
+
     public static setTokenSymbol(token: TokenWrapper, newSymbol: string) {
         let oldSymbol = token.symbol;
 
@@ -880,18 +903,18 @@ export default class StateManager {
 
 
     public static set alphabet(newAlphabet: Array<TokenWrapper>) {
-        const oldAlphabet = StateManager._alphabet;
+        // const oldAlphabet = StateManager._alphabet;
         StateManager._alphabet = newAlphabet;
 
-        oldAlphabet.forEach(tok => {
-            if (!newAlphabet.includes(tok)) {
-                // The token tok was removed from the alphabet, so we need
-                // to remove it from any transitions!
-                StateManager._transitionWrappers.forEach(transition => {
-                    transition.removeToken(tok);
-                });
-            }
-        });
+        // oldAlphabet.forEach(tok => {
+        //     if (!newAlphabet.includes(tok)) {
+        //         // The token tok was removed from the alphabet, so we need
+        //         // to remove it from any transitions!
+        //         StateManager._transitionWrappers.forEach(transition => {
+        //             transition.removeToken(tok);
+        //         });
+        //     }
+        // });
     }
 
     public static get alphabet() {
@@ -1198,6 +1221,11 @@ class SetTransitionAcceptsTokenData extends ActionData {
 
 class AddTokenActionData extends ActionData {
     public token: TokenWrapper;
+}
+
+class RemoveTokenActionData extends ActionData {
+    public token: TokenWrapper;
+    public transitionsUsingToken: TransitionWrapper[];
 }
 
 class SetTokenSymbolActionData extends ActionData {

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -541,6 +541,46 @@ export default class StateManager {
         UndoRedoManager.pushAction(setTransitionDoesntAcceptTokenAction);
     }
 
+    public static setTransitionAcceptsEpsilon(transition: TransitionWrapper) {
+        let hadEpsilonBefore = transition.isEpsilonTransition;
+
+        let setTransitionAcceptsEpsilonForward = (data: SetTransitionAcceptsTokenData) => {
+            data.transition.isEpsilonTransition = true;
+        };
+
+        let setTransitionAcceptsEpsilonBackward = (data: SetTransitionAcceptsTokenData) => {
+            data.transition.isEpsilonTransition = hadEpsilonBefore;
+        }
+        let setTransitionAcceptsTokenAction = new Action(
+            "setTransitionAcceptsEpsilon",
+            `Use ε For Transition "${transition.sourceNode.labelText}" To "${transition.destNode.labelText}"`,
+            setTransitionAcceptsEpsilonForward,
+            setTransitionAcceptsEpsilonBackward,
+            { 'transition': transition, 'token': null }
+        );
+        UndoRedoManager.pushAction(setTransitionAcceptsTokenAction);
+    }
+
+    public static setTransitionDoesntAcceptEpsilon(transition: TransitionWrapper) {
+        let hadEpsilonBefore = transition.isEpsilonTransition;
+
+        let setTransitionDoesntAcceptEpsilonForward = (data: SetTransitionAcceptsTokenData) => {
+            data.transition.isEpsilonTransition = false;
+        };
+
+        let setTransitionDoesntAcceptEpsilonBackward = (data: SetTransitionAcceptsTokenData) => {
+            data.transition.isEpsilonTransition = hadEpsilonBefore;
+        }
+        let setTransitionDoesntAcceptTokenAction = new Action(
+            "setTransitionDoesntAcceptEpsilon",
+            `Don't Use ε For Transition "${transition.sourceNode.labelText}" To "${transition.destNode.labelText}"`,
+            setTransitionDoesntAcceptEpsilonForward,
+            setTransitionDoesntAcceptEpsilonBackward,
+            { 'transition': transition, 'token': null }
+        );
+        UndoRedoManager.pushAction(setTransitionDoesntAcceptTokenAction);
+    }
+
     public static get tentativeTransitionInProgress() {
         return StateManager._tentativeTransitionSource !== null;
     }

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -291,6 +291,26 @@ export default class StateManager {
         UndoRedoManager.pushAction(createStateAction);
     }
 
+    public static setNodeName(nodeWrapper: NodeWrapper, newName: string) {
+        let oldName = nodeWrapper.labelText;
+
+        let setNodeNameForward = (data: SetNodeNameActionData) => {
+            data.nodeWrapper.labelText = data.newName;
+        };
+
+        let setNodeNameBackward = (data: SetNodeNameActionData) => {
+            data.nodeWrapper.labelText = data.oldName;
+        };
+
+        let setNodeNameAction = new Action(
+            "setNodeName",
+            setNodeNameForward,
+            setNodeNameBackward,
+            {'oldName': oldName, 'newName': newName, 'nodeWrapper': nodeWrapper}
+        );
+        UndoRedoManager.pushAction(setNodeNameAction);
+    }
+
 
 
     public static addTransition(transition: TransitionWrapper) {
@@ -852,4 +872,10 @@ class CreateNodeActionData extends ActionData {
 class MoveStatesActionData extends ActionData {
     public delta: Vector2d;
     public states: Array<NodeWrapper>;
+}
+
+class SetNodeNameActionData extends ActionData {
+    public oldName: string;
+    public newName: string;
+    public nodeWrapper: NodeWrapper;
 }

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -604,12 +604,9 @@ export default class StateManager {
                 });
             }
         });
-
-        console.log('alphabet is', StateManager._alphabet);
     }
 
     public static get alphabet() {
-        console.log('alphabet is', StateManager._alphabet);
         return [...StateManager._alphabet];
     }
 

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -262,7 +262,8 @@ export default class StateManager {
             y = Math.round(y / gridSpacing) * gridSpacing;
         }
 
-        const newStateWrapper = new NodeWrapper(`q${StateManager._nextStateId++}`);
+        const newStateWrapperName = `q${StateManager._nextStateId++}`;
+        const newStateWrapper = new NodeWrapper(newStateWrapperName);
         let createStateForward = (data: CreateNodeActionData) => {
             newStateWrapper.createKonvaObjects(data.x, data.y);
             StateManager._nodeWrappers.push(newStateWrapper);
@@ -284,6 +285,7 @@ export default class StateManager {
 
         let createStateAction = new Action(
             "createState",
+            `Create "${newStateWrapperName}"`,
             createStateForward,
             createStateBackward,
             {'x': x, 'y': y, "nodeWrapper": null}
@@ -304,6 +306,7 @@ export default class StateManager {
 
         let setNodeNameAction = new Action(
             "setNodeName",
+            `Rename "${oldName}" To "${newName}"`,
             setNodeNameForward,
             setNodeNameBackward,
             {'oldName': oldName, 'newName': newName, 'nodeWrapper': nodeWrapper}
@@ -324,6 +327,7 @@ export default class StateManager {
 
         let setNodeIsAcceptAction = new Action(
             "setNodeIsAccept",
+            `Mark "${nodeWrapper.labelText}" as ${isAccept ? 'Accepting' : 'Rejecting'}`,
             setNodeIsAcceptForward,
             setNodeIsAcceptBackward,
             {'oldValue': oldValue, 'newValue': isAccept, 'nodeWrapper': nodeWrapper}
@@ -344,6 +348,7 @@ export default class StateManager {
 
         let setNodeIsStartAction = new Action(
             "setNodeIsStart",
+            `Set "${nodeWrapper?.labelText ?? 'none'}" As Initial Node`,
             setNodeIsStartForward,
             setNodeIsStartBackward,
             {'oldStart': oldStart, 'newStart': nodeWrapper}
@@ -863,8 +868,18 @@ export default class StateManager {
             });
         };
 
+        let moveStatesString = "Move ";
+        if (this.selectedObjects.length > 1) {
+            moveStatesString += `${this.selectedObjects.length} Nodes`;
+        }
+        else if (this.selectedObjects.length == 1) {
+            let singleState = this.selectedObjects[0] as NodeWrapper;
+            moveStatesString += `"${singleState.labelText}"`;
+        }
+
         let moveNodesAction = new Action(
             "moveStates",
+            moveStatesString,
             moveStatesForward,
             moveStatesBackward,
             {delta: delta, states: [...this.selectedObjects]}

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -331,6 +331,26 @@ export default class StateManager {
         UndoRedoManager.pushAction(setNodeIsAcceptAction);
     }
 
+    public static setNodeIsStart(nodeWrapper: NodeWrapper) {
+        let oldStart = StateManager._startNode;
+
+        let setNodeIsStartForward = (data: SetNodeIsStartActionData) => {
+            StateManager.startNode = data.newStart;
+        };
+
+        let setNodeIsStartBackward = (data: SetNodeIsStartActionData) => {
+            StateManager.startNode = data.oldStart;
+        };
+
+        let setNodeIsStartAction = new Action(
+            "setNodeIsStart",
+            setNodeIsStartForward,
+            setNodeIsStartBackward,
+            {'oldStart': oldStart, 'newStart': nodeWrapper}
+        );
+        UndoRedoManager.pushAction(setNodeIsStartAction);
+    }
+
 
 
     public static addTransition(transition: TransitionWrapper) {
@@ -904,4 +924,9 @@ class SetNodeIsAcceptActionData extends ActionData {
     public oldValue: boolean;
     public newValue: boolean;
     public nodeWrapper: NodeWrapper;
+}
+
+class SetNodeIsStartActionData extends ActionData {
+    public oldStart: NodeWrapper;
+    public newStart: NodeWrapper;
 }

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -310,7 +310,7 @@ export default class StateManager {
                 transition.konvaGroup.remove();
             });
 
-            StateManager._transitionLayer.draw();
+            StateManager.updateTransitions();
 
             // Remove the state itself
             StateManager._nodeWrappers = StateManager._nodeWrappers.filter(node => {
@@ -341,7 +341,7 @@ export default class StateManager {
                 StateManager._transitionWrappers.push(transition);
                 StateManager._transitionLayer.add(transition.konvaGroup);
             });
-            StateManager._transitionLayer.draw();
+            StateManager.updateTransitions();
         };
 
         let deleteNodeAction = new Action(
@@ -534,13 +534,13 @@ export default class StateManager {
         let addTransitionForward = (data: AddTransitionActionData) => {
             StateManager._transitionWrappers.push(data.transition);
             StateManager._transitionLayer.add(newTransitionWrapper.konvaGroup);
-            StateManager._transitionLayer.draw();
+            StateManager.updateTransitions();
         };
 
         let addTransitionBackward = (data: AddTransitionActionData) => {
             StateManager._transitionWrappers = StateManager._transitionWrappers.filter(i => i !== data.transition);
             newTransitionWrapper.konvaGroup.remove();
-            StateManager._transitionLayer.draw();
+            StateManager.updateTransitions();
         };
 
         let addTransitionAction = new Action(
@@ -558,14 +558,14 @@ export default class StateManager {
             StateManager._transitionWrappers = StateManager._transitionWrappers.filter(otherTransition => otherTransition !== data.transitionWrapper);
 
             data.transitionWrapper.konvaGroup.remove();
-            StateManager._transitionLayer.draw();
+            StateManager.updateTransitions();
         };
 
         let deleteTransitionBackward = (data: DeleteTransitionActionData) => {
             StateManager._transitionWrappers.push(data.transitionWrapper);
 
             StateManager._transitionLayer.add(data.transitionWrapper.konvaGroup);
-            StateManager._transitionLayer.draw();
+            StateManager.updateTransitions();
         };
 
         let deleteTransitionAction = new Action(
@@ -1075,6 +1075,7 @@ export default class StateManager {
                     this.updateStartNodePosition();
                 }
             });
+            StateManager.updateTransitions();
         };
 
         let moveStatesBackward = (data: MoveStatesActionData) => {
@@ -1088,6 +1089,7 @@ export default class StateManager {
                     this.updateStartNodePosition();
                 }
             });
+            StateManager.updateTransitions();
         };
 
         let moveStatesString = "Move ";
@@ -1108,6 +1110,13 @@ export default class StateManager {
         );
 
         UndoRedoManager.pushAction(moveNodesAction, false);
+    }
+
+    public static updateTransitions() {
+        StateManager._transitionWrappers.forEach(trans => {
+            trans.updatePoints();
+        });
+        StateManager._transitionLayer.draw();
     }
 }
 

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -261,8 +261,9 @@ export default class StateManager {
             y = Math.round(y / gridSpacing) * gridSpacing;
         }
 
+        const newStateWrapper = new NodeWrapper(`q${StateManager._nextStateId++}`);
         let createStateForward = (data: CreateNodeActionData) => {
-            const newStateWrapper = new NodeWrapper(x, y);
+            newStateWrapper.createKonvaObjects(data.x, data.y);
             StateManager._nodeWrappers.push(newStateWrapper);
             StateManager._nodeLayer?.add(newStateWrapper.nodeGroup);
 
@@ -277,11 +278,15 @@ export default class StateManager {
         };
 
         let createStateBackward = (data: CreateNodeActionData) => {
-            // Delete the state and all of its transitions.
             this.deleteNode(data.nodeWrapper);
         };
 
-        let createStateAction = new Action("createState", createStateForward, createStateBackward, {'x': x, 'y': y, "nodeWrapper": null});
+        let createStateAction = new Action(
+            "createState",
+            createStateForward,
+            createStateBackward,
+            {'x': x, 'y': y, "nodeWrapper": null}
+        );
         UndoRedoManager.pushAction(createStateAction);
     }
 
@@ -684,7 +689,8 @@ export default class StateManager {
 
         // Load each state
         states.forEach(state => {
-            const newState = new NodeWrapper(state.x, state.y, state.label, acceptStates.includes(state.id), state.id);
+            const newState = new NodeWrapper(state.label, state.id);
+            newState.createKonvaObjects(state.x, state.y);
             StateManager._nodeWrappers.push(newState);
             StateManager._nodeLayer.add(newState.nodeGroup);
         });

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -1,0 +1,54 @@
+
+export default class UndoRedoManager {
+    // The stack we push actions onto and pop off.
+    private static _stack: Array<Action> = [];
+
+    // Our current location within the action stack.
+    // This will usually be equal to _stack.length - 1,
+    // indicating that we are at the top of the stack.
+    // However, if we start undoing actions, we will move
+    // down the stack. 
+    private static _stackLocation: number = -1;
+
+    public static pushAction(action: Action) {
+        if (this._stack.length == this._stackLocation - 1) {
+            // We are at the top of the stack, so we can
+            // just add this new action to the top.
+            this._stack.push(action);
+        } else {
+            // We are not at the top of the stack, so we
+            // need to remove all of the actions from the
+            // top down to the current one(??) - may want
+            // to double check this.
+            while (this._stack.length > this._stackLocation - 1) {
+                this._stack.pop();
+            }
+            this._stack.push(action);
+        }
+        action.forward();
+    }
+
+    public static redo() {
+        if (this._stackLocation == this._stack.length - 1) {
+            console.error("Can't redo because we're at the top of the stack");
+            return;
+        }
+        this._stackLocation += 1;
+        this._stack[this._stackLocation].forward();
+    }
+
+    public static undo() {
+        if (this._stackLocation == -1) {
+            console.error("Can't undo because the stack is empty");
+            return;
+        }
+        this._stack[this._stackLocation].backward();
+        this._stackLocation -= 1;
+    }
+}
+
+export class Action {
+    public name: string;
+    public forward: () => void;
+    public backward: () => void;
+}

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -20,15 +20,14 @@ export default class UndoRedoManager {
         } else {
             // We are not at the top of the stack, so we
             // need to remove all of the actions from the
-            // top down to the current one(??) - may want
-            // to double check this.
-            while (this._stack.length > 0 && this._stack.length > this._stackLocation - 1) {
+            // top down to the current one.
+            while (this._stack.length > 0 && this._stackLocation < this._stack.length - 1) {
                 this._stack.pop();
             }
             this._stack.push(action);
             this._stackLocation = this._stack.length - 1;
         }
-        
+
         if (performForward) {
             action.forward();
         }
@@ -50,7 +49,6 @@ export default class UndoRedoManager {
         }
         this._stack[this._stackLocation].backward();
         this._stackLocation -= 1;
-        console.log(`Undo completed, stack location is now ${this._stackLocation}/${this._stack.length - 1}`);
     }
 }
 

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -21,8 +21,7 @@ export default class UndoRedoManager {
             // need to remove all of the actions from the
             // top down to the current one(??) - may want
             // to double check this.
-            while (this._stack.length > this._stackLocation) {
-                console.log(`Stack length is currently ${this._stack.length} but needs to get back to ${this._stackLocation}, so pop one`)
+            while (this._stack.length > 0 && this._stack.length > this._stackLocation - 1) {
                 this._stack.pop();
             }
             this._stack.push(action);

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -11,6 +11,9 @@ export default class UndoRedoManager {
     // down the stack. 
     private static _stackLocation: number = -1;
 
+    // A set of functions to call when the stack changes.
+    private static _listeners: Set<() => void> = new Set<() => void>();
+
     public static pushAction(action: Action, performForward: boolean = true) {
         if (this._stackLocation == this._stack.length - 1) {
             // We are at the top of the stack, so we can
@@ -31,6 +34,8 @@ export default class UndoRedoManager {
         if (performForward) {
             action.forward();
         }
+
+        this.callListeners();
     }
 
     public static redo() {
@@ -40,6 +45,7 @@ export default class UndoRedoManager {
         }
         this._stackLocation += 1;
         this._stack[this._stackLocation].forward();
+        this.callListeners();
     }
 
     public static undo() {
@@ -49,6 +55,29 @@ export default class UndoRedoManager {
         }
         this._stack[this._stackLocation].backward();
         this._stackLocation -= 1;
+        this.callListeners();
+    }
+
+    // TODO: Pass a copy of the stack rather than the stack itself,
+    // to prevent modifications
+    public static getStack() {
+        return this._stack;
+    }
+
+    public static getStackLocation() {
+        return this._stackLocation;
+    }
+
+    public static startListeningOnStackChanged(listener: () => void) {
+        this._listeners.add(listener);
+    }
+
+    public static stopListeningOnStackChanged(listener: () => void) {
+        this._listeners.delete(listener);
+    }
+
+    private static callListeners() {
+        this._listeners.forEach(listener => listener());
     }
 }
 

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -11,11 +11,12 @@ export default class UndoRedoManager {
     // down the stack. 
     private static _stackLocation: number = -1;
 
-    public static pushAction(action: Action) {
+    public static pushAction(action: Action, performForward: boolean = true) {
         if (this._stackLocation == this._stack.length - 1) {
             // We are at the top of the stack, so we can
             // just add this new action to the top.
             this._stack.push(action);
+            this._stackLocation += 1;
         } else {
             // We are not at the top of the stack, so we
             // need to remove all of the actions from the
@@ -25,9 +26,12 @@ export default class UndoRedoManager {
                 this._stack.pop();
             }
             this._stack.push(action);
+            this._stackLocation = this._stack.length - 1;
         }
-        this._stackLocation += 1;
-        action.forward();
+        
+        if (performForward) {
+            action.forward();
+        }
     }
 
     public static redo() {

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -54,12 +54,14 @@ export default class UndoRedoManager {
 
 export class Action {
     public name: string;
+    public displayString: string;
     private _forward: (data: ActionData) => void;
     private _backward: (data: ActionData) => void;
     private _data: ActionData;
 
-    constructor(name: string, forward: (data: ActionData) => void, backward: (data: ActionData) => void, data: ActionData) {
+    constructor(name: string, displayString: string, forward: (data: ActionData) => void, backward: (data: ActionData) => void, data: ActionData) {
         this.name = name;
+        this.displayString = displayString;
         this._forward = forward;
         this._backward = backward;
         this._data = data;
@@ -67,12 +69,12 @@ export class Action {
 
     public forward() {
         this._forward(this._data);
-        console.log(`Action "${this.name}" performed forward!`);
+        console.log(`FORWARD: ${this.displayString}`);
     }
 
     public backward() {
         this._backward(this._data);
-        console.log(`Action "${this.name}" performed backward!`);
+        console.log(`BACKWARD: ${this.displayString}`);
     }
 }
 

--- a/src/UndoRedoManager.ts
+++ b/src/UndoRedoManager.ts
@@ -1,3 +1,4 @@
+import NodeWrapper from "./NodeWrapper";
 
 export default class UndoRedoManager {
     // The stack we push actions onto and pop off.
@@ -11,7 +12,7 @@ export default class UndoRedoManager {
     private static _stackLocation: number = -1;
 
     public static pushAction(action: Action) {
-        if (this._stack.length == this._stackLocation - 1) {
+        if (this._stackLocation == this._stack.length - 1) {
             // We are at the top of the stack, so we can
             // just add this new action to the top.
             this._stack.push(action);
@@ -20,11 +21,13 @@ export default class UndoRedoManager {
             // need to remove all of the actions from the
             // top down to the current one(??) - may want
             // to double check this.
-            while (this._stack.length > this._stackLocation - 1) {
+            while (this._stack.length > this._stackLocation) {
+                console.log(`Stack length is currently ${this._stack.length} but needs to get back to ${this._stackLocation}, so pop one`)
                 this._stack.pop();
             }
             this._stack.push(action);
         }
+        this._stackLocation += 1;
         action.forward();
     }
 
@@ -44,11 +47,32 @@ export default class UndoRedoManager {
         }
         this._stack[this._stackLocation].backward();
         this._stackLocation -= 1;
+        console.log(`Undo completed, stack location is now ${this._stackLocation}/${this._stack.length - 1}`);
     }
 }
 
 export class Action {
     public name: string;
-    public forward: () => void;
-    public backward: () => void;
+    private _forward: (data: ActionData) => void;
+    private _backward: (data: ActionData) => void;
+    private _data: ActionData;
+
+    constructor(name: string, forward: (data: ActionData) => void, backward: (data: ActionData) => void, data: ActionData) {
+        this.name = name;
+        this._forward = forward;
+        this._backward = backward;
+        this._data = data;
+    }
+
+    public forward() {
+        this._forward(this._data);
+        console.log(`Action "${this.name}" performed forward!`);
+    }
+
+    public backward() {
+        this._backward(this._data);
+        console.log(`Action "${this.name}" performed backward!`);
+    }
 }
+
+export class ActionData {}

--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -3,26 +3,32 @@ import TokenWrapper from "../TokenWrapper";
 import StateManager from "../StateManager";
 import { CoreListItem, CoreListItem_Left, ListItem } from "./ListItem";
 import { BsPlusCircleFill, BsXCircleFill } from "react-icons/bs";
+import { useActionStack } from "../utilities/ActionStackUtilities";
 
 interface ListItem_TokenEditorProps {
-    tokenWrapper: TokenWrapper
+    token: TokenWrapper
     removeFunc: (tk: TokenWrapper) => void
 }
 
 function ListItem_TokenEditor(props: React.PropsWithChildren<ListItem_TokenEditorProps>) {
-    const tw = props.tokenWrapper;
+    const tw = props.token;
     const [tokenSymbol, setTokenSymbol] = useState(tw.symbol);
 
+    let updateTokenSymbol = (newSymbol: string) => {
+        setTokenSymbol(newSymbol);
+        StateManager.setTokenSymbol(tw, newSymbol);
+    };
+    
+    const [_, currentStackLocation] = useActionStack();
     useEffect(() => {
-        // tw.symbol = tokenSymbol;
-        StateManager.setTokenSymbol(tw, tokenSymbol);
-    }, [tokenSymbol]);
+        setTokenSymbol(tw.symbol);
+    }, [currentStackLocation]);
 
     return (
         <CoreListItem>
             <div className="flex flex-row">
                 <div className="flex-1 grow float-left">
-                    <input className="focus:outline-none bg-transparent" type="text" minLength={1} maxLength={1} placeholder="Token symbol" value={tokenSymbol} onChange={e => setTokenSymbol(e.target.value)}></input>
+                    <input className="focus:outline-none bg-transparent" type="text" minLength={1} maxLength={1} placeholder="Token symbol" value={tokenSymbol} onChange={e => updateTokenSymbol(e.target.value)}></input>
                 </div>
                 <button className="flex-0 float-right px-2 block text-center text-red-500 align-middle" onClick={() => props.removeFunc(tw)}>
                     <BsXCircleFill />
@@ -56,7 +62,7 @@ function AlphabetList() {
     //     StateManager.alphabet = alphabet;
     // }, [alphabet]);
 
-    const tokenWrapperElements = alphabet.map(tw => <ListItem_TokenEditor tokenWrapper={tw} removeFunc={removeTokenFromAlphabet} key={tw.id} />);
+    const tokenWrapperElements = alphabet.map(tw => <ListItem_TokenEditor token={tw} removeFunc={removeTokenFromAlphabet} key={tw.id} />);
 
     return (<>
         <div className="mt-3 ml-1 mb-1">

--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -7,7 +7,6 @@ import { useActionStack } from "../utilities/ActionStackUtilities";
 
 interface ListItem_TokenEditorProps {
     token: TokenWrapper
-    removeFunc: (tk: TokenWrapper) => void
 }
 
 function ListItem_TokenEditor(props: React.PropsWithChildren<ListItem_TokenEditorProps>) {
@@ -30,7 +29,7 @@ function ListItem_TokenEditor(props: React.PropsWithChildren<ListItem_TokenEdito
                 <div className="flex-1 grow float-left">
                     <input className="focus:outline-none bg-transparent" type="text" minLength={1} maxLength={1} placeholder="Token symbol" value={tokenSymbol} onChange={e => updateTokenSymbol(e.target.value)}></input>
                 </div>
-                <button className="flex-0 float-right px-2 block text-center text-red-500 align-middle" onClick={() => props.removeFunc(tw)}>
+                <button className="flex-0 float-right px-2 block text-center text-red-500 align-middle" onClick={() => StateManager.removeToken(tw)}>
                     <BsXCircleFill />
                 </button>
             </div>
@@ -47,22 +46,22 @@ function AlphabetList() {
 
     function addTokenToAlphabet() {
         StateManager.addToken();
-        setAlphabet(StateManager.alphabet);
+        // setAlphabet(StateManager.alphabet);
         // const newAlphabet = [...alphabet];
         // newAlphabet.push(new TokenWrapper());
         // setAlphabet(newAlphabet);
-    }
-
-    function removeTokenFromAlphabet(tk: TokenWrapper) {
-        const newAlphabet = alphabet.filter(i => i !== tk);
-        setAlphabet(newAlphabet);
     }
 
     // useEffect(() => {
     //     StateManager.alphabet = alphabet;
     // }, [alphabet]);
 
-    const tokenWrapperElements = alphabet.map(tw => <ListItem_TokenEditor token={tw} removeFunc={removeTokenFromAlphabet} key={tw.id} />);
+    const [_, currentStackLocation] = useActionStack();
+    useEffect(() => {
+        setAlphabet(StateManager.alphabet);
+    }, [currentStackLocation]);
+
+    const tokenWrapperElements = alphabet.map(tw => <ListItem_TokenEditor token={tw} key={tw.id} />);
 
     return (<>
         <div className="mt-3 ml-1 mb-1">

--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -14,7 +14,8 @@ function ListItem_TokenEditor(props: React.PropsWithChildren<ListItem_TokenEdito
     const [tokenSymbol, setTokenSymbol] = useState(tw.symbol);
 
     useEffect(() => {
-        tw.symbol = tokenSymbol;
+        // tw.symbol = tokenSymbol;
+        StateManager.setTokenSymbol(tw, tokenSymbol);
     }, [tokenSymbol]);
 
     return (
@@ -39,9 +40,11 @@ function AlphabetList() {
     const [alphabet, setAlphabet] = useState(StateManager.alphabet);
 
     function addTokenToAlphabet() {
-        const newAlphabet = [...alphabet];
-        newAlphabet.push(new TokenWrapper());
-        setAlphabet(newAlphabet);
+        StateManager.addToken();
+        setAlphabet(StateManager.alphabet);
+        // const newAlphabet = [...alphabet];
+        // newAlphabet.push(new TokenWrapper());
+        // setAlphabet(newAlphabet);
     }
 
     function removeTokenFromAlphabet(tk: TokenWrapper) {
@@ -49,9 +52,9 @@ function AlphabetList() {
         setAlphabet(newAlphabet);
     }
 
-    useEffect(() => {
-        StateManager.alphabet = alphabet;
-    }, [alphabet]);
+    // useEffect(() => {
+    //     StateManager.alphabet = alphabet;
+    // }, [alphabet]);
 
     const tokenWrapperElements = alphabet.map(tw => <ListItem_TokenEditor tokenWrapper={tw} removeFunc={removeTokenFromAlphabet} key={tw.id} />);
 

--- a/src/components/DetailsBox/DetailsBox.tsx
+++ b/src/components/DetailsBox/DetailsBox.tsx
@@ -13,7 +13,6 @@ interface DetailsBoxProps {
   selection: Array<SelectableObject>;
   startNode: NodeWrapper;
   setStartNode: React.Dispatch<React.SetStateAction<NodeWrapper>>;
-  setLastUpdated: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function DetailsBox(props: DetailsBoxProps) {
@@ -36,7 +35,7 @@ export default function DetailsBox(props: DetailsBoxProps) {
         />
       );
     } else if (item instanceof TransitionWrapper) {
-      return <DetailsBox_TransitionSelection key={item.id} transitionWrapper={item} setLastUpdated={props.setLastUpdated}/>;
+      return <DetailsBox_TransitionSelection key={item.id} transition={item} />;
     }
     return <div key={`unhandled-${index}`}>Unhandled item type</div>;
   });

--- a/src/components/DetailsBox/DetailsBox_ActionStackViewer.tsx
+++ b/src/components/DetailsBox/DetailsBox_ActionStackViewer.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import StateManager from "../../StateManager";
+import UndoRedoManager, { Action } from "../../UndoRedoManager";
+
+interface ActionRowItemProps {
+    displayString: string;
+    greyedOut: boolean;
+}
+
+function useActionStack(): [Array<Action>, number] {
+    const [currentStack, setCurrentStack] = useState([]);
+    const [currentStackLocation, setCurrentStackLocation] = useState(-1);
+
+    useEffect(() => {
+        function handleStackChanged() {
+            let newStack = UndoRedoManager.getStack().map(i => i).reverse();
+            setCurrentStack(newStack);
+            setCurrentStackLocation(UndoRedoManager.getStackLocation());
+        }
+        UndoRedoManager.startListeningOnStackChanged(handleStackChanged);
+        return () => {
+            UndoRedoManager.stopListeningOnStackChanged(handleStackChanged);
+        }
+    }, []);
+    return [currentStack, currentStackLocation];
+}
+
+function ActionRowItem(props: ActionRowItemProps) {
+    return (<div className={`border-t-2 border-zinc-400 ${props.greyedOut ? 'text-slate-500' : ''}`}>
+        {props.displayString}
+    </div>)
+}
+
+export default function DetailsBox_ActionStackViewer() {
+    const [currentStack, currentStackLocation] = useActionStack();
+    let stackItems = currentStack.map((action, index) => {
+        return <ActionRowItem
+            displayString={action.displayString}
+            greyedOut={currentStack.length - index - 1 > currentStackLocation}
+        />;
+    });
+
+    return (
+        <div className="flex flex-col">
+            <div className="font-medium text-2xl">Action Stack</div>
+            <div>
+                {stackItems}
+            </div>
+        </div>
+    );
+}

--- a/src/components/DetailsBox/DetailsBox_ActionStackViewer.tsx
+++ b/src/components/DetailsBox/DetailsBox_ActionStackViewer.tsx
@@ -1,28 +1,11 @@
 import { useState, useEffect } from "react";
 import StateManager from "../../StateManager";
 import UndoRedoManager, { Action } from "../../UndoRedoManager";
+import { useActionStack } from "../../utilities/ActionStackUtilities";
 
 interface ActionRowItemProps {
     displayString: string;
     greyedOut: boolean;
-}
-
-function useActionStack(): [Array<Action>, number] {
-    const [currentStack, setCurrentStack] = useState([]);
-    const [currentStackLocation, setCurrentStackLocation] = useState(-1);
-
-    useEffect(() => {
-        function handleStackChanged() {
-            let newStack = UndoRedoManager.getStack().map(i => i).reverse();
-            setCurrentStack(newStack);
-            setCurrentStackLocation(UndoRedoManager.getStackLocation());
-        }
-        UndoRedoManager.startListeningOnStackChanged(handleStackChanged);
-        return () => {
-            UndoRedoManager.stopListeningOnStackChanged(handleStackChanged);
-        }
-    }, []);
-    return [currentStack, currentStackLocation];
 }
 
 function ActionRowItem(props: ActionRowItemProps) {

--- a/src/components/DetailsBox/DetailsBox_AlphabetEditor.tsx
+++ b/src/components/DetailsBox/DetailsBox_AlphabetEditor.tsx
@@ -36,6 +36,7 @@ export default function DetailsBox_AlphabetEditor() {
 
     function removeTokenFromAlphabet(tk: TokenWrapper) {
         const newAlphabet = alphabet.filter(i => i !== tk);
+        StateManager.removeToken(tk);
         setAlphabet(newAlphabet);
     }
 

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -11,14 +11,19 @@ interface DetailsBox_StateSelectionProps {
 }
 
 interface SetStartStateButtonProps {
-    nodeWrapper: NodeWrapper
-    startNode: NodeWrapper
-    setStartNode: React.Dispatch<React.SetStateAction<NodeWrapper>>
+    node: NodeWrapper;
 }
 
 function SetStartStateButton(props: SetStartStateButtonProps) {
+    const [isStartNodeInternal, setIsStartNodeInternal] = useState(StateManager.startNode === props.node);
+
+    const [_, currentStackLocation] = useActionStack();
+    useEffect(() => {
+        setIsStartNodeInternal(StateManager.startNode === props.node);
+    }, [currentStackLocation]);
+
     let classes = 'rounded-full p-2 m-1 mx-2 block ';
-    if (StateManager.startNode === props.nodeWrapper) {
+    if (isStartNodeInternal) {
         return (<button
             className={classes + 'bg-slate-400 text-gray-700'}
             disabled={true}>
@@ -28,7 +33,7 @@ function SetStartStateButton(props: SetStartStateButtonProps) {
     else {
         return <button
             className={classes + 'bg-emerald-500 text-white'}
-            onClick={e => props.setStartNode(props.nodeWrapper)}>
+            onClick={_ => StateManager.setNodeIsStart(props.node)}>
             Set Start State
         </button>
     }
@@ -54,7 +59,7 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
         StateManager.setNodeIsAccept(nw, isAccept);
     };
 
-    const [currentStack, currentStackLocation] = useActionStack();
+    const [_, currentStackLocation] = useActionStack();
     useEffect(() => {
         setIsAcceptNode(nw.isAcceptNode);
     }, [currentStackLocation]);
@@ -67,7 +72,7 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
                 <input className="flex-1 bg-transparent" type="text" placeholder="State name" value={nodeLabelText} onChange={e => setLabelText(e.target.value)}></input>
 
             </div>
-            <SetStartStateButton nodeWrapper={nw} startNode={props.startNode} setStartNode={props.setStartNode} />
+            <SetStartStateButton node={nw} />
             <div>
                 <input type="checkbox" id="is-accept-state" name="is-accept-state" checked={isAcceptNode} onChange={e => updateNodeIsAccept(e.target.checked)}></input>
                 <label htmlFor="is-accept-state">Accept State</label>

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -40,12 +40,17 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
     const [nodeLabelText, setLabelText] = useState(nw.labelText);
     const [isAcceptNode, setIsAcceptNode] = useState(nw.isAcceptNode);
 
+    // TODO: These may be triggered, and thus register actions, when the nodes
+    // are clicked even though the user didn't do anything.
+    // To fix this, the functions may need to be called more explicitly from
+    // the onChange callers?
+    // (Maybe we don't need these useEffect calls at all?)
     useEffect(() => {
         StateManager.setNodeName(nw, nodeLabelText);
     }, [nodeLabelText]);
 
     useEffect(() => {
-        nw.isAcceptNode = isAcceptNode;
+        StateManager.setNodeIsAccept(nw, isAcceptNode);
     }, [isAcceptNode]);
 
     return (

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -45,14 +45,10 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
     const [nodeLabelText, setLabelText] = useState(nw.labelText);
     const [isAcceptNode, setIsAcceptNode] = useState(nw.isAcceptNode);
 
-    // TODO: These may be triggered, and thus register actions, when the nodes
-    // are clicked even though the user didn't do anything.
-    // To fix this, the functions may need to be called more explicitly from
-    // the onChange callers?
-    // (Maybe we don't need these useEffect calls at all?)
-    useEffect(() => {
-        StateManager.setNodeName(nw, nodeLabelText);
-    }, [nodeLabelText]);
+    let updateNodeName = (newName: string) => {
+        setLabelText(newName);
+        StateManager.setNodeName(nw, newName);
+    };
 
     let updateNodeIsAccept = (isAccept: boolean) => {
         setIsAcceptNode(isAccept);
@@ -61,6 +57,7 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
 
     const [_, currentStackLocation] = useActionStack();
     useEffect(() => {
+        setLabelText(nw.labelText);
         setIsAcceptNode(nw.isAcceptNode);
     }, [currentStackLocation]);
 
@@ -69,7 +66,7 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
             <div className="font-medium text-2xl">State</div>
             <div className="flex flex-row">
                 <div className="flex-1 mr-4">Name</div>
-                <input className="flex-1 bg-transparent" type="text" placeholder="State name" value={nodeLabelText} onChange={e => setLabelText(e.target.value)}></input>
+                <input className="flex-1 bg-transparent" type="text" placeholder="State name" value={nodeLabelText} onChange={e => updateNodeName(e.target.value)}></input>
 
             </div>
             <SetStartStateButton node={nw} />

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -41,7 +41,7 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
     const [isAcceptNode, setIsAcceptNode] = useState(nw.isAcceptNode);
 
     useEffect(() => {
-        nw.labelText = nodeLabelText;
+        StateManager.setNodeName(nw, nodeLabelText);
     }, [nodeLabelText]);
 
     useEffect(() => {

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -34,7 +34,6 @@ function SetStartStateButton(props: SetStartStateButtonProps) {
 
 }
 
-
 export default function DetailsBox_StateSelection(props: DetailsBox_StateSelectionProps) {
     const nw = props.nodeWrapper;
     const [nodeLabelText, setLabelText] = useState(nw.labelText);
@@ -49,9 +48,10 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
         StateManager.setNodeName(nw, nodeLabelText);
     }, [nodeLabelText]);
 
-    useEffect(() => {
-        StateManager.setNodeIsAccept(nw, isAcceptNode);
-    }, [isAcceptNode]);
+    let updateNodeIsAccept = (isAccept: boolean) => {
+        setIsAcceptNode(isAccept);
+        StateManager.setNodeIsAccept(nw, isAccept);
+    };
 
     return (
         <div className="flex flex-col">
@@ -63,7 +63,7 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
             </div>
             <SetStartStateButton nodeWrapper={nw} startNode={props.startNode} setStartNode={props.setStartNode} />
             <div>
-                <input type="checkbox" id="is-accept-state" name="is-accept-state" checked={isAcceptNode} onChange={e => setIsAcceptNode(e.target.checked)}></input>
+                <input type="checkbox" id="is-accept-state" name="is-accept-state" checked={isAcceptNode} onChange={e => updateNodeIsAccept(e.target.checked)}></input>
                 <label htmlFor="is-accept-state">Accept State</label>
             </div>
         </div>

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import NodeWrapper from "../../NodeWrapper";
 import SelectableObject from "../../SelectableObject";
 import StateManager from "../../StateManager";
+import { useActionStack } from "../../utilities/ActionStackUtilities";
 
 interface DetailsBox_StateSelectionProps {
     nodeWrapper: NodeWrapper
@@ -52,6 +53,11 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
         setIsAcceptNode(isAccept);
         StateManager.setNodeIsAccept(nw, isAccept);
     };
+
+    const [currentStack, currentStackLocation] = useActionStack();
+    useEffect(() => {
+        setIsAcceptNode(nw.isAcceptNode);
+    }, [currentStackLocation]);
 
     return (
         <div className="flex flex-col">

--- a/src/components/DetailsBox/DetailsBox_TransitionSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_TransitionSelection.tsx
@@ -50,7 +50,11 @@ export default function DetailsBox_TransitionSelection(props: DetailsBox_Transit
     const [isEpsilonTransition, setEpsilonTransition] = useState(tw.isEpsilonTransition);
 
     useEffect(() => {
-        tw.isEpsilonTransition = isEpsilonTransition;
+        if (isEpsilonTransition) {
+            StateManager.setTransitionAcceptsEpsilon(tw);
+        } else {
+            StateManager.setTransitionDoesntAcceptEpsilon(tw);
+        }
         props.setLastUpdated(new Date().getTime());
     }, [isEpsilonTransition]);
 

--- a/src/components/DetailsBox/DetailsBox_TransitionSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_TransitionSelection.tsx
@@ -4,59 +4,68 @@ import SelectableObject from "../../SelectableObject";
 import StateManager from "../../StateManager";
 import TransitionWrapper from "../../TransitionWrapper";
 import TokenWrapper from "../../TokenWrapper";
+import { useActionStack } from "../../utilities/ActionStackUtilities";
 
 interface DetailsBox_TransitionSelectionProps {
-    transitionWrapper: TransitionWrapper;
-    setLastUpdated: React.Dispatch<React.SetStateAction<number>>;
+    transition: TransitionWrapper;
 }
 
 interface DetailsBox_TransitionTokenCheckBoxProps {
-    transitionWrapper: TransitionWrapper;
-    tokenWrapper: TokenWrapper;
-    setLastUpdated: React.Dispatch<React.SetStateAction<number>>;
+    transition: TransitionWrapper;
+    token: TokenWrapper;
 }
 
 function DetailsBox_TransitionTokenCheckBox(props: DetailsBox_TransitionTokenCheckBoxProps) {
-    const token = props.tokenWrapper;
-    const transition = props.transitionWrapper;
+    const token = props.token;
+    const transition = props.transition;
 
     const [tokenIsIncluded, setTokenIsIncluded] = useState(transition.hasToken(token));
-    useEffect(() => {
-        if (tokenIsIncluded) {
-            // transition.addToken(token);
+
+    let updateTokenIsIncluded = (isIncluded: boolean) => {
+        setTokenIsIncluded(isIncluded);
+
+        if (isIncluded) {
             StateManager.setTransitionAcceptsToken(transition, token);
-        }
-        else {
-            // transition.removeToken(token);
+        } else {
             StateManager.setTransitionDoesntAcceptToken(transition, token);
         }
-        props.setLastUpdated(new Date().getTime());
-    }, [tokenIsIncluded]);
+    };
+
+    const [_, currentStackLocation] = useActionStack();
+    useEffect(() => {
+        setTokenIsIncluded(transition.hasToken(token));
+    }, [currentStackLocation]);
 
     return (
         <div key={token.id}>
-            <input type="checkbox" id="is-epsilon-transition" name={`transition-accepts-${token.id}`} checked={tokenIsIncluded} onChange={e => setTokenIsIncluded(e.target.checked)}></input>
+            <input type="checkbox" id="is-epsilon-transition" name={`transition-accepts-${token.id}`} checked={tokenIsIncluded} onChange={e => updateTokenIsIncluded(e.target.checked)}></input>
             <label htmlFor={`transition-accepts-${token.id}`}>{token.symbol}</label>
         </div>
     )
 }
 
 export default function DetailsBox_TransitionSelection(props: DetailsBox_TransitionSelectionProps) {
-    const tw = props.transitionWrapper;
+    const tw = props.transition;
 
     const srcNode = tw.sourceNode;
     const dstNode = tw.destNode;
 
     const [isEpsilonTransition, setEpsilonTransition] = useState(tw.isEpsilonTransition);
 
-    useEffect(() => {
-        if (isEpsilonTransition) {
+    let updateIsEpsilonTransition = (isEpsilon: boolean) => {
+        setEpsilonTransition(isEpsilon);
+
+        if (isEpsilon) {
             StateManager.setTransitionAcceptsEpsilon(tw);
         } else {
             StateManager.setTransitionDoesntAcceptEpsilon(tw);
         }
-        props.setLastUpdated(new Date().getTime());
-    }, [isEpsilonTransition]);
+    };
+
+    const [_, currentStackLocation] = useActionStack();
+    useEffect(() => {
+        setEpsilonTransition(tw.isEpsilonTransition);
+    }, [currentStackLocation]);
 
     return (
         <div className="flex flex-col">
@@ -66,10 +75,10 @@ export default function DetailsBox_TransitionSelection(props: DetailsBox_Transit
                 Transition on:
             </div>
             <div>
-                <input type="checkbox" id="is-epsilon-transition" name="is-epsilon-transition" checked={isEpsilonTransition} onChange={e => setEpsilonTransition(e.target.checked)}></input>
+                <input type="checkbox" id="is-epsilon-transition" name="is-epsilon-transition" checked={isEpsilonTransition} onChange={e => updateIsEpsilonTransition(e.target.checked)}></input>
                 <label htmlFor="is-epsilon-transition">ε</label>
             </div>
-            {StateManager.alphabet.map((token) => <DetailsBox_TransitionTokenCheckBox transitionWrapper={tw} tokenWrapper={token} setLastUpdated={props.setLastUpdated}/>)}
+            {StateManager.alphabet.map((token) => <DetailsBox_TransitionTokenCheckBox transition={tw} token={token} />)}
         </div>
     );
 }

--- a/src/components/DetailsBox/DetailsBox_TransitionSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_TransitionSelection.tsx
@@ -23,10 +23,12 @@ function DetailsBox_TransitionTokenCheckBox(props: DetailsBox_TransitionTokenChe
     const [tokenIsIncluded, setTokenIsIncluded] = useState(transition.hasToken(token));
     useEffect(() => {
         if (tokenIsIncluded) {
-            transition.addToken(token);
+            // transition.addToken(token);
+            StateManager.setTransitionAcceptsToken(transition, token);
         }
         else {
-            transition.removeToken(token);
+            // transition.removeToken(token);
+            StateManager.setTransitionDoesntAcceptToken(transition, token);
         }
         props.setLastUpdated(new Date().getTime());
     }, [tokenIsIncluded]);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import TestStringWindow from './components/TestStringWindow';
 import InformationBox, { InformationBoxType } from './components/InformationBox';
 import { testStringOnAutomata } from './components/TestStringOnAutomata';
 import {  } from './components/TestStringWindow';
+import DetailsBox_ActionStackViewer from './components/DetailsBox/DetailsBox_ActionStackViewer';
 
 function App() {
     const [currentTool, setCurrentTool] = useState(Tool.States);
@@ -178,6 +179,11 @@ function App() {
                                 </div>
                             </button>
                         </div>
+                    </FloatingPanel>
+                </div>
+                <div>
+                    <FloatingPanel heightPolicy='min' style={{ width: '250px' }}>
+                        <DetailsBox_ActionStackViewer />
                     </FloatingPanel>
                 </div>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,12 +92,6 @@ function App() {
         StateManager.useDarkMode = useDarkMode;
     }, [useDarkMode]);
 
-    // The purpose of this is to allow us to force the GUI to refresh
-    // whenever the automaton is changed, so we can check for errors again.
-    // This may be a hacky solution that we should revisit.
-    const [lastUpdated, setLastUpdated] = useState(0);
-    
-
     // Create a DFA from the current state, and get the errors from it
     let dfa = StateManager.dfa;
     let dfaErrors = dfa.getErrors();
@@ -117,7 +111,6 @@ function App() {
                             selection={selectedObjects}
                             startNode={startNode}
                             setStartNode={setStartNode}
-                            setLastUpdated={setLastUpdated}
                         />
 
                         {errorBoxes}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,7 @@ function App() {
     }, [selectedObjects]);
 
     useEffect(() => {
-        StateManager.startNode = startNode;
+        StateManager.setNodeIsStart(startNode);
     }, [startNode]);
 
     const emptyStringToken = StateManager.alphabet.some(token => token.symbol.trim() === '');

--- a/src/utilities/ActionStackUtilities.tsx
+++ b/src/utilities/ActionStackUtilities.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+import StateManager from "../StateManager";
+import UndoRedoManager, { Action } from "../UndoRedoManager";
+
+export function useActionStack(): [Array<Action>, number] {
+    const [currentStack, setCurrentStack] = useState([]);
+    const [currentStackLocation, setCurrentStackLocation] = useState(-1);
+
+    useEffect(() => {
+        function handleStackChanged() {
+            let newStack = UndoRedoManager.getStack().map(i => i).reverse();
+            setCurrentStack(newStack);
+            setCurrentStackLocation(UndoRedoManager.getStackLocation());
+        }
+        UndoRedoManager.startListeningOnStackChanged(handleStackChanged);
+        return () => {
+            UndoRedoManager.stopListeningOnStackChanged(handleStackChanged);
+        }
+    }, []);
+    return [currentStack, currentStackLocation];
+}


### PR DESCRIPTION
This PR adds basic undo/redo functionality to the program, closing #82.
- Pressing Control + Z on Windows (Command + Z on macOS) will step backwards one action in the stack.
- Pressing Shift + Control + Z on Windows (Shift + Command + Z on macOS) will step forwards one action in the stack.
  - If not at the top of the stack, performing an action will irreversibly clear all items on the stack above the current position.

Currently, the stack's contents are visualized in the "Action Stack" panel.
![CleanShot 2024-08-29 at 21 47 39@2x](https://github.com/user-attachments/assets/165ab256-2b79-4242-8807-c2c8f8c71b3c)

When the user moves down the stack via undo actions, items in the stack above the current position (i.e., actions that the user could use "Redo" to get to) are greyed out.

![CleanShot 2024-08-29 at 21 50 22@2x](https://github.com/user-attachments/assets/cc37da86-c38b-4afc-ad6a-cc1527153b9e)

There are *not* currently on-screen UI buttons for undoing/redoing, but they should be trivial to add.
Additionally, a future PR may move the "Action Stack" panel to a different tab on the left-most panel, or another location that saves more on-screen space for the diagram itself.