### PR TITLE
Modal window animates in and out

### DIFF
--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -1,4 +1,5 @@
 import { BsXLg } from "react-icons/bs";
+import { motion } from "framer-motion";
 
 interface ClosableModalWindowProps {
     title?: string,
@@ -26,14 +27,18 @@ export function ClosableModalWindow(props: React.PropsWithChildren<ClosableModal
 export default function ModalWindow(props: React.PropsWithChildren) {
     return (
         <>
-            <div className={`fixed inset-0 z-40 bg-gray-500/50 dark:bg-gray-950/70 transition-opacity backdrop-blur-sm`}></div>
-            <div className={`fixed inset-0 z-50 w-screen overflow-y-auto`}>
-                <div className={`flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0`}>
-                    <div className='relative transform overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 dark:text-white text-left shadow-xl transition-all sm:w-full sm:max-w-lg'>
-                        {props.children}
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                <div className={`z-40 fixed inset-0 bg-gray-500/50 dark:bg-gray-950/70`}></div>
+                <div className={`fixed inset-0 z-50 w-screen overflow-y-auto`}>
+                    <div className={`flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0`}>
+                        <motion.div initial={{ y: -30 }} animate={{ y: 0 }} exit={{ y: -30 }}>
+                            <div className='relative transform overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 dark:text-white text-left shadow-xl sm:w-full sm:max-w-lg'>
+                                {props.children}
+                            </div>
+                        </motion.div>
                     </div>
                 </div>
-            </div>
+            </motion.div>
         </>
     );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import InformationBox, { InformationBoxType } from './components/InformationBox'
 import { testStringOnAutomata } from './components/TestStringOnAutomata';
 import {  } from './components/TestStringWindow';
 import DetailsBox_ActionStackViewer from './components/DetailsBox/DetailsBox_ActionStackViewer';
+import { motion, AnimatePresence } from 'framer-motion';
 
 function App() {
     const [currentTool, setCurrentTool] = useState(Tool.States);
@@ -184,7 +185,17 @@ function App() {
                     <Toolbox currentTool={currentTool} setCurrentTool={setCurrentTool} />
                 </FloatingPanel>
             </div>
-            {configWindowOpen && <ClosableModalWindow title='Configure Automaton' close={closeConfigWindow}><ConfigureAutomatonWindow /></ClosableModalWindow>}
+            {
+                <AnimatePresence>
+                    {configWindowOpen && (
+                        <motion.div>
+                            <ClosableModalWindow title='Configure Automaton' close={closeConfigWindow}>
+                                <ConfigureAutomatonWindow />
+                            </ClosableModalWindow>
+                        </motion.div>
+                        )}
+                </AnimatePresence>
+            }
         </div>
     );
 }


### PR DESCRIPTION
This PR makes the "Configure Automaton" modal window animate in and out, rather than suddenly appearing and disappearing.

It also removes the blur effect from the background. I found that the blur effect wasn't working well with the animation, and additionally, users may want to view their state diagram in the background.

In testing on my end, I have found there is a minor visual bug where the Toolbar isn't impacted by the background darkening animation. I think this can be addressed as a separate issue.