### PR TITLE
Move Enable Snap to Grid Button to Toolbox

### DIFF
--- a/src/components/DetailsBox/DetailsBox.tsx
+++ b/src/components/DetailsBox/DetailsBox.tsx
@@ -1,11 +1,9 @@
-import { useState } from 'react';
 import NodeWrapper from "../../NodeWrapper";
 import SelectableObject from "../../SelectableObject";
 import TransitionWrapper from "../../TransitionWrapper";
 import DetailsBox_NoSelection from "./DetailsBox_NoSelection";
 import DetailsBox_StateSelection from "./DetailsBox_StateSelection";
 import DetailsBox_TransitionSelection from "./DetailsBox_TransitionSelection";
-import StateManager from '../../StateManager';
 
 interface DetailsBoxProps {
   selection: Array<SelectableObject>;
@@ -24,14 +22,6 @@ interface DetailsBoxProps {
  * @returns 
  */
 export default function DetailsBox(props: DetailsBoxProps) {
-  const [isSnapActive, setIsSnapActive] = useState(StateManager.snapToGridEnabled);
-
-  // Function to toggle snap to grid feature on/off
-  const handleToggleSnap = () => {
-    StateManager.toggleSnapToGrid();
-    setIsSnapActive(!isSnapActive); // Toggle the local UI state
-  };
-
   // For each item selected display its corresponding editor
   const selectionElements = props.selection.map((item, index) => {
     if (item instanceof NodeWrapper) {
@@ -49,20 +39,10 @@ export default function DetailsBox(props: DetailsBoxProps) {
     return <div key={`unhandled-${index}`}>Unhandled item type</div>;
   });
 
-  // The bottom toggle button is always rendered outside of the selectionElements logic
   return (
     <div className="details-box flex flex-col h-full">
       <div className="flex-1 overflow-auto">
         {selectionElements.length > 0 ? selectionElements : <DetailsBox_NoSelection />}
-      </div>
-      {/* Always render the toggle button at the bottom */}
-      <div className="p-2 flex justify-center mt-auto">
-        <button
-          onClick={handleToggleSnap}
-          className={`text-white font-bold py-2 px-4 rounded-full my-2 w-full ${isSnapActive ? 'bg-blue-700' : 'bg-blue-500'}`}
-        >
-          {isSnapActive ? 'Disable Snap to Grid' : 'Enable Snap to Grid'}
-        </button>
       </div>
     </div>
   );

--- a/src/components/Toolbox.tsx
+++ b/src/components/Toolbox.tsx
@@ -2,8 +2,10 @@ import { Tool } from '../Tool';
 import ToolButton from './ToolButton';
 import StateManager from '../StateManager';
 import { useRef } from 'react';
+import { useState } from 'react';
 import { BsCursor, BsCursorFill, BsDownload, BsNodePlus, BsNodePlusFill, BsPlusCircle, BsPlusCircleFill, BsUpload, BsZoomIn, BsZoomOut, BsFillArrowLeftCircleFill, BsFillArrowRightCircleFill } from 'react-icons/bs';
 import { TbZoomReset } from "react-icons/tb";
+import { GrGrid } from "react-icons/gr";
 import { BiCake, BiReset, BiSave, BiTrash } from "react-icons/bi";
 
 interface ToolboxProps {
@@ -18,7 +20,14 @@ interface ToolboxProps {
  * @param {React.Dispatch<React.SetStateAction<Tool>>} props.setCurrentTool A function for setting the current tool.
  */
 export default function Toolbox(props: React.PropsWithChildren<ToolboxProps>) {
+    const [isSnapActive, setIsSnapActive] = useState(StateManager.snapToGridEnabled);
     const fileInputRef = useRef<HTMLInputElement>(null); // Create a ref for the file input
+
+    // Function to toggle snap to grid feature on/off
+    const handleToggleSnap = () => {
+        StateManager.toggleSnapToGrid();
+        setIsSnapActive(!isSnapActive); // Toggle the local UI state
+    };
 
     // Function to trigger file input click event
     const handleLoadButtonClick = () => {
@@ -43,6 +52,12 @@ export default function Toolbox(props: React.PropsWithChildren<ToolboxProps>) {
                 </div>
             </ToolButton>
             <div className='grow'></div>
+            {/* Enable Snap to Grid Button */}
+            <button className={`rounded-full p-2 m-1 mx-2 block text-white text-center ${isSnapActive ? 'bg-fuchsia-800' : 'bg-fuchsia-500'}`} onClick={handleToggleSnap} title={isSnapActive ? 'Disable Snap to Grid' : 'Enable Snap to Grid'}>
+                <div className='flex flex-row items-center justify-center'>  
+                    <GrGrid />
+                </div>
+            </button>
             <button className='rounded-full p-2 m-1 mx-2 block bg-amber-500 text-white text-center' onClick={StateManager.downloadJSON} title="Download from JSON">
                 <BsDownload />
             </button>


### PR DESCRIPTION
I moved the enable snap to grid button from the details box to the toolbox. I thought the best place to place the button was before the JSON file download/upload buttons but after the tool buttons. This way, the user can quickly access snap to grid toggling when selecting and adding states. This PR addresses issue #99 