### PR TITLE
Rename toJSON function to toSerializable, set return types as well

### DIFF
--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -75,8 +75,7 @@ export default class NodeWrapper extends SelectableObject {
 
   /**
    * Converts this node wrapper into an object that can be serialized.
-   * @returns {object} An object that can be serialized. Note that this is
-   * **not** a JSON string.
+   * @returns {SerializableState} A serializable state object.
    */
   public toSerializable(): SerializableState {
     return {

--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -1,5 +1,5 @@
 import Konva from 'konva';
-import StateManager from './StateManager';
+import StateManager, { SerializableState } from './StateManager';
 import { Tool } from './Tool';
 import { Vector2d } from 'konva/lib/types';
 import SelectableObject from './SelectableObject';
@@ -74,11 +74,11 @@ export default class NodeWrapper extends SelectableObject {
   }
 
   /**
-   * Converts this node wrapper into a JSON object that can be serialized.
-   * @returns {object} A JSON object that can be serialized. Note that this is
+   * Converts this node wrapper into an object that can be serialized.
+   * @returns {object} An object that can be serialized. Note that this is
    * **not** a JSON string.
    */
-  public toJSON() {
+  public toSerializable(): SerializableState {
     return {
       id: this.id,
       x: this.nodeGroup.x(),

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1466,8 +1466,8 @@ export default class StateManager {
 
     /**
      * Converts the current automaton into an object that can be
-     * serialized. Note that this is *not* a JSON string.
-     * @returns 
+     * serialized.
+     * @returns {SerializableAutomaton} A serializable automaton object.
      */
     public static toSerializable(): SerializableAutomaton {
         return {

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1436,7 +1436,7 @@ export default class StateManager {
     /** Gets a runnable DFA object from the current automaton. */
     public static get dfa(): DFA {
         let outputDFA = new DFA();
-        const stateManagerData = StateManager.toJSON();
+        const stateManagerData = StateManager.toSerializable();
         outputDFA.inputAlphabet = stateManagerData.alphabet.map((s) => s.symbol);
         outputDFA.states = stateManagerData.states.map((s) => new DFAState(s.label));
         outputDFA.acceptStates = stateManagerData.acceptStates.map((s) => {
@@ -1465,15 +1465,15 @@ export default class StateManager {
     }
 
     /**
-     * Converts the current automaton into a JSON object that can be
+     * Converts the current automaton into an object that can be
      * serialized. Note that this is *not* a JSON string.
      * @returns 
      */
-    public static toJSON() {
+    public static toSerializable(): SerializableAutomaton {
         return {
-            states: StateManager._nodeWrappers.map(node => node.toJSON()),
-            alphabet: StateManager._alphabet.map(tok => tok.toJSON()),
-            transitions: StateManager._transitionWrappers.map(trans => trans.toJSON()),
+            states: StateManager._nodeWrappers.map(node => node.toSerializable()),
+            alphabet: StateManager._alphabet.map(tok => tok.toSerializable()),
+            transitions: StateManager._transitionWrappers.map(trans => trans.toSerializable()),
             startState: StateManager._startNode != null ? StateManager._startNode.id : null,
             acceptStates: StateManager._nodeWrappers.filter(node => node.isAcceptNode).map(node => node.id)
         };
@@ -1484,7 +1484,7 @@ export default class StateManager {
      * user's device.
      */
     public static downloadJSON() {
-        const jsonString = JSON.stringify(StateManager.toJSON(), null, 4);
+        const jsonString = JSON.stringify(StateManager.toSerializable(), null, 4);
 
         // A hacky solution in my opinion, but apparently it works so hey.
         // Adapted from https://stackoverflow.com/a/18197341
@@ -1725,7 +1725,7 @@ interface SerializableAutomaton {
 /**
  * A representation of a node that can be converted to and from a JSON string.
  */
-interface SerializableState {
+export interface SerializableState {
     id: string,
     x: number,
     y: number,
@@ -1735,7 +1735,7 @@ interface SerializableState {
 /**
  * A representation of a token that can be converted to and from a JSON string.
  */
-interface SerializableToken {
+export interface SerializableToken {
     id: string,
     symbol: string
 }
@@ -1744,7 +1744,7 @@ interface SerializableToken {
  * A representation of a transition that can be converted to and from a JSON
  * string.
  */
-interface SerializableTransition {
+export interface SerializableTransition {
     id: string,
     source: string,
     dest: string,

--- a/src/TokenWrapper.ts
+++ b/src/TokenWrapper.ts
@@ -1,4 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
+import { SerializableToken } from './StateManager';
+
 
 /**
  * The class that holds token information and acts as a persistent reference
@@ -40,11 +42,11 @@ export default class TokenWrapper {
     }
 
     /**
-     * Converts this token wrapper into a JSON object that can be serialized.
-     * @returns A JSON object that can be serialized. Note that this
+     * Converts this token wrapper into an object that can be serialized.
+     * @returns A object that can be serialized. Note that this
      * is *not* a JSON string.
      */
-    public toJSON() {
+    public toSerializable(): SerializableToken {
         return {
             id: this.id,
             symbol: this.symbol

--- a/src/TokenWrapper.ts
+++ b/src/TokenWrapper.ts
@@ -43,8 +43,7 @@ export default class TokenWrapper {
 
     /**
      * Converts this token wrapper into an object that can be serialized.
-     * @returns A object that can be serialized. Note that this
-     * is *not* a JSON string.
+     * @returns {SerializableToken} A serializable token object.
      */
     public toSerializable(): SerializableToken {
         return {

--- a/src/TransitionWrapper.ts
+++ b/src/TransitionWrapper.ts
@@ -1,7 +1,7 @@
 import Konva from "konva";
 import NodeWrapper from "./NodeWrapper";
 import SelectableObject from "./SelectableObject";
-import StateManager from "./StateManager";
+import StateManager, { SerializableTransition } from './StateManager';
 import { Tool } from "./Tool";
 import TokenWrapper from "./TokenWrapper";
 import { v4 as uuidv4 } from 'uuid';
@@ -378,11 +378,11 @@ export default class TransitionWrapper extends SelectableObject {
     }
 
     /**
-     * Converts this transition wrapper into a JSON object that can be serialized.
-     * @returns A JSON object that can be serialized. Note that this
+     * Converts this transition wrapper into an object that can be serialized.
+     * @returns An object that can be serialized. Note that this
      * is *not* a JSON string.
      */
-    public toJSON() {
+    public toSerializable(): SerializableTransition {
         return {
             id: this.id,
             source: this._sourceNode.id,

--- a/src/TransitionWrapper.ts
+++ b/src/TransitionWrapper.ts
@@ -379,8 +379,7 @@ export default class TransitionWrapper extends SelectableObject {
 
     /**
      * Converts this transition wrapper into an object that can be serialized.
-     * @returns An object that can be serialized. Note that this
-     * is *not* a JSON string.
+     * @returns {SerializableTransition} The serializable transition object.
      */
     public toSerializable(): SerializableTransition {
         return {


### PR DESCRIPTION
I renamed the toJSON functions to be toSerializable. I also set their return types to be the corresponding serializable object as discussed in issue #114.