### PR TITLE
Fix Bug Where Toolbox UI Overlaps Configure Automaton Modal During Transition Animation

### DIFF
--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -50,18 +50,16 @@ export function ClosableModalWindow(props: React.PropsWithChildren<ClosableModal
 export default function ModalWindow(props: React.PropsWithChildren) {
     return (
         <>
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-                <div className={`z-40 fixed inset-0 bg-gray-500/50 dark:bg-gray-950/70`}></div>
-                <div className={`fixed inset-0 z-50 w-screen overflow-y-auto`}>
-                    <div className={`flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0`}>
-                        <motion.div initial={{ y: -30 }} animate={{ y: 0 }} exit={{ y: -30 }}>
-                            <div className='relative transform overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 dark:text-white text-left shadow-xl sm:w-full sm:max-w-lg'>
-                                {props.children}
-                            </div>
-                        </motion.div>
-                    </div>
-                </div>
-            </motion.div>
+            <div className={`z-40 fixed inset-0 bg-gray-500/50 dark:bg-gray-950/70`}></div>
+            <div className={`fixed inset-0 z-50 w-screen overflow-y-auto`}>
+                <div className={`flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0`}>
+                    <motion.div initial={{ opacity: 0,  y: -30 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -30 }}>
+                        <div className='relative transform overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 dark:text-white text-left shadow-xl sm:w-full sm:max-w-lg'>
+                            {props.children}
+                        </div>
+                    </motion.div>
+                </div>            
+            </div>
         </>
     );
 }


### PR DESCRIPTION
The Configure Automaton modal did not have a set z-index before entering its transition animation causing the toolbox UI to overlap the modal during its animations. Setting the modal window's z-index before defining its motion values appears to fix this problem. This PR addresses issue #94 