### PR TITLE
Fix #131: Rename 'Clear the Automaton' to 'New Automaton'

### DIFF
--- a/src/components/Toolbox.tsx
+++ b/src/components/Toolbox.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { BsCursor, BsCursorFill, BsDownload, BsNodePlus, BsNodePlusFill, BsPlusCircle, BsPlusCircleFill, BsUpload, BsZoomIn, BsZoomOut, BsFillArrowLeftCircleFill, BsFillArrowRightCircleFill } from 'react-icons/bs';
 import { TbZoomReset } from "react-icons/tb";
 import { GrGrid } from "react-icons/gr";
-import { BiCake, BiReset, BiSave, BiTrash } from "react-icons/bi";
+import { BiCake, BiFileBlank, BiReset, BiSave, BiTrash } from "react-icons/bi";
 
 interface ToolboxProps {
     currentTool: Tool
@@ -82,7 +82,7 @@ export default function Toolbox(props: React.PropsWithChildren<ToolboxProps>) {
             {/* Zoom Out Button */}
             <ActionButton onClick={StateManager.zoomOut} icon={<BsZoomOut />} title="Zoom Out" bgColor="bg-blue-500"></ActionButton>
             {/* Clear Stage No Save Button */}
-            <ActionButton onClick={StateManager.clearMachine} icon={<BiTrash />} title="Clear the Automaton" bgColor="bg-red-500" margin="m-10"></ActionButton>
+            <ActionButton onClick={StateManager.clearMachine} icon={<BiFileBlank />} title="New Automaton" bgColor="bg-black" margin="m-10"></ActionButton>
             {/* Undo Button */}
             <ActionButton onClick={StateManager.undoState} icon={<BsFillArrowLeftCircleFill />} title="Undo most recent action" bgColor="bg-blue-500"></ActionButton>
             {/* Redo Button */}


### PR DESCRIPTION
Hello,
Hope you're doing well
As it has been requested in issue #131, I have renamed the hover title from `Clear the Automaton` to `New Automaton`
Additionally, I have changed the icon and its background color too as discussed in the original issue
This is how the UI looks after the code changes:
1) Light Mode:
![image](https://github.com/user-attachments/assets/71822554-a92e-41df-993e-3d337ebfdb1a)

2) Dark Mode:
![image](https://github.com/user-attachments/assets/f1b1dbd0-9028-428a-ae3d-fe50331cc03d)

Do let me know if there are any changes required from my end in order to fix the requirement
Sincere apologies for my mistakes or misunderstandings if you find any

Thanks and Regards,
Mohit Kambli