### PR TITLE
Snap to grid action stack fix

### DIFF
--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -43,6 +43,9 @@ export default class NodeWrapper extends SelectableObject {
 
   private lastPos: Vector2d;
 
+  /** The previous grid aligned position. */
+  private lastSnappedPos: Vector2d = { x: 0, y: 0 };
+
   /**
    * Whether or not this node is an accepting node.
    * 
@@ -427,7 +430,12 @@ export default class NodeWrapper extends SelectableObject {
       // Redraw the layer to reflect the changes
       this.nodeGroup.getLayer()?.batchDraw();
 
-      StateManager.completeDragStatesOperation(this.nodeGroup.position());
+      // only add the move to the action stack if our snapped position changed
+      if (Math.abs(this.lastSnappedPos.x - snappedX) > 1e-5 || 
+          Math.abs(this.lastSnappedPos.y - snappedY) > 1e-5) {
+        this.lastSnappedPos = { x: snappedX, y: snappedY };
+        StateManager.completeDragStatesOperation(this.nodeGroup.position());
+      }
     } else if (StateManager.currentTool === Tool.Transitions) {
       // Handling specific to ending a tentative transition
       StateManager.endTentativeTransition();

--- a/src/NodeWrapper.ts
+++ b/src/NodeWrapper.ts
@@ -427,6 +427,7 @@ export default class NodeWrapper extends SelectableObject {
       // Redraw the layer to reflect the changes
       this.nodeGroup.getLayer()?.batchDraw();
 
+      StateManager.completeDragStatesOperation(this.nodeGroup.position());
     } else if (StateManager.currentTool === Tool.Transitions) {
       // Handling specific to ending a tentative transition
       StateManager.endTentativeTransition();


### PR DESCRIPTION
Made the action stack update when snapToGrid is enabled. The action stack only updates if the snapped position changes. This PR addresses issue #112.