### PR TITLE
Fix Bug: UI Can Push Page Beyond Canvas

### DIFF
--- a/src/components/DetailsBox/DetailsBox.tsx
+++ b/src/components/DetailsBox/DetailsBox.tsx
@@ -40,7 +40,7 @@ export default function DetailsBox(props: DetailsBoxProps) {
   });
 
   return (
-    <div className="details-box flex flex-col h-full">
+    <div className="details-box flex flex-col h-min">
       <div className="flex-1 overflow-auto">
         {selectionElements.length > 0 ? selectionElements : <DetailsBox_NoSelection />}
       </div>

--- a/src/components/FloatingPanel.tsx
+++ b/src/components/FloatingPanel.tsx
@@ -18,7 +18,7 @@ export default function FloatingPanel(props: React.PropsWithChildren<FloatingPan
 
     return (
         <div className='flex flex-col'>
-            <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} max-h-screen p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl overflow-y-auto`} style={props.style}>
+            <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl overflow-y-auto`} style={props.style}>
                 {props.children}
             </div>
         </div>

--- a/src/components/FloatingPanel.tsx
+++ b/src/components/FloatingPanel.tsx
@@ -17,7 +17,7 @@ interface FloatingPanelProps {
 export default function FloatingPanel(props: React.PropsWithChildren<FloatingPanelProps>) {
 
     return (
-        <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl resize-x`} style={props.style}>
+        <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} max-h-screen p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl resize-x overflow-y-auto`} style={props.style}>
             {props.children}
         </div>
     );

--- a/src/components/FloatingPanel.tsx
+++ b/src/components/FloatingPanel.tsx
@@ -17,8 +17,10 @@ interface FloatingPanelProps {
 export default function FloatingPanel(props: React.PropsWithChildren<FloatingPanelProps>) {
 
     return (
-        <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} max-h-screen p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl overflow-y-auto`} style={props.style}>
-            {props.children}
+        <div className='flex flex-col'>
+            <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} max-h-screen p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl overflow-y-auto`} style={props.style}>
+                {props.children}
+            </div>
         </div>
     );
 }

--- a/src/components/FloatingPanel.tsx
+++ b/src/components/FloatingPanel.tsx
@@ -17,7 +17,7 @@ interface FloatingPanelProps {
 export default function FloatingPanel(props: React.PropsWithChildren<FloatingPanelProps>) {
 
     return (
-        <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} max-h-screen p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl resize-x overflow-y-auto`} style={props.style}>
+        <div className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} max-h-screen p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl overflow-y-auto`} style={props.style}>
             {props.children}
         </div>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -121,85 +121,82 @@ function App() {
         <div className={useDarkMode ? 'dark' : ''}>
             <NodeView />
             <div className='flex flex-row h-screen text-center'>
-                <div className='flex flex-col'>
-                    <FloatingPanel heightPolicy='min' style={{ width: '300px' }}>
-                        <DetailsBox
-                            selection={selectedObjects}
-                            startNode={startNode}
-                            setStartNode={setStartNode}
-                        />
+                <FloatingPanel heightPolicy='min' style={{ width: '300px' }}>
+                    <DetailsBox
+                        selection={selectedObjects}
+                        startNode={startNode}
+                        setStartNode={setStartNode}
+                    />
 
-                        <div className='max-h-96 overflow-y-auto'>
-                            <AnimatePresence>
-                                {errorBoxes}
-                            </AnimatePresence>
-                        </div>
+                    <div className='max-h-96 overflow-y-auto'>
+                        <AnimatePresence>
+                            {errorBoxes}
+                        </AnimatePresence>
+                    </div>
 
 
-                        {/* Example error message boxes commented out */}
-                        {/*
-                        <InformationBox infoBoxType={InformationBoxType.Error}>
-                            State "q0" has multiple transitions for token "a"
-                        </InformationBox>
-                        <InformationBox infoBoxType={InformationBoxType.Error}>
-                            State "q0" has no transition for token "b"
-                        </InformationBox>
-                        <InformationBox infoBoxType={InformationBoxType.Error}>
-                            Transitions on empty string (ε) not allowed in DFA
-                        </InformationBox>
-                        <InformationBox infoBoxType={InformationBoxType.Error}>
-                            Alphabet needs at least one token
-                        </InformationBox>
-                        <InformationBox infoBoxType={InformationBoxType.Error}>
-                            Token "c" is repeated in alphabet
-                        </InformationBox>
-                        <InformationBox infoBoxType={InformationBoxType.Warning}>
-                            State "q3" is inaccessible
-                        </InformationBox>
-                        <InformationBox infoBoxType={InformationBoxType.Warning}>
-                            Accept state "q4" is inaccessible; automaton will always reject
-                        </InformationBox>
-                        */}
+                    {/* Example error message boxes commented out */}
+                    {/*
+                    <InformationBox infoBoxType={InformationBoxType.Error}>
+                        State "q0" has multiple transitions for token "a"
+                    </InformationBox>
+                    <InformationBox infoBoxType={InformationBoxType.Error}>
+                        State "q0" has no transition for token "b"
+                    </InformationBox>
+                    <InformationBox infoBoxType={InformationBoxType.Error}>
+                        Transitions on empty string (ε) not allowed in DFA
+                    </InformationBox>
+                    <InformationBox infoBoxType={InformationBoxType.Error}>
+                        Alphabet needs at least one token
+                    </InformationBox>
+                    <InformationBox infoBoxType={InformationBoxType.Error}>
+                        Token "c" is repeated in alphabet
+                    </InformationBox>
+                    <InformationBox infoBoxType={InformationBoxType.Warning}>
+                        State "q3" is inaccessible
+                    </InformationBox>
+                    <InformationBox infoBoxType={InformationBoxType.Warning}>
+                        Accept state "q4" is inaccessible; automaton will always reject
+                    </InformationBox>
+                    */}
 
-                        <TestStringWindow />
-                        {!isLabelUnique && (
-                            <InformationBox infoBoxType={InformationBoxType.Error}>
-                                Duplicate state labels detected. Each state must have a unique label.
-                            </InformationBox>
-                        )}
-                        {emptyStringToken && (
-                            <InformationBox infoBoxType={InformationBoxType.Error}>
-                                Invalid token: Empty string detected.
-                            </InformationBox>
-                        )}
+                    <TestStringWindow />
+                    {!isLabelUnique && (
+                        <InformationBox infoBoxType={InformationBoxType.Error}>
+                            Duplicate state labels detected. Each state must have a unique label.
+                        </InformationBox>
+                    )}
+                    {emptyStringToken && (
+                        <InformationBox infoBoxType={InformationBoxType.Error}>
+                            Invalid token: Empty string detected.
+                        </InformationBox>
+                    )}
 
-                        <div className="flex flex-col items-center mt-4">
-                            <button
-                                className="rounded-full p-2 m-1 mx-2 block bg-amber-500 text-white text-center"
-                                onClick={openConfigWindow}
-                            >
-                                <div className='flex flex-row items-center place-content-center mx-2'>
-                                    <BsGearFill className='mr-1' />
-                                    Configure Automaton
-                                </div>
-                            </button>
-                            <button
-                                className="rounded-full p-2 m-1 mx-2 block bg-gray-500 text-white text-center"
-                                onClick={toggleDarkMode}
-                            >
-                                <div className='flex flex-row items-center place-content-center mx-2'>
-                                    <BsMoonFill className='mr-1' />
-                                    Dark Mode
-                                </div>
-                            </button>
-                        </div>
-                    </FloatingPanel>
-                </div>
-                <div className='flex flex-col'>
-                    <FloatingPanel heightPolicy='min' style={{ width: '250px' }}>
-                        <DetailsBox_ActionStackViewer />
-                    </FloatingPanel>
-                </div>
+                    <div className="flex flex-col items-center mt-4">
+                        <button
+                            className="rounded-full p-2 m-1 mx-2 block bg-amber-500 text-white text-center"
+                            onClick={openConfigWindow}
+                        >
+                            <div className='flex flex-row items-center place-content-center mx-2'>
+                                <BsGearFill className='mr-1' />
+                                Configure Automaton
+                            </div>
+                        </button>
+                        <button
+                            className="rounded-full p-2 m-1 mx-2 block bg-gray-500 text-white text-center"
+                            onClick={toggleDarkMode}
+                        >
+                            <div className='flex flex-row items-center place-content-center mx-2'>
+                                <BsMoonFill className='mr-1' />
+                                Dark Mode
+                            </div>
+                        </button>
+                    </div>
+                </FloatingPanel>
+
+                <FloatingPanel heightPolicy='min' style={{ width: '250px' }}>
+                    <DetailsBox_ActionStackViewer />
+                </FloatingPanel>
 
                 <FloatingPanel heightPolicy='min'>
                     <Toolbox currentTool={currentTool} setCurrentTool={setCurrentTool} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -129,9 +129,11 @@ function App() {
                             setStartNode={setStartNode}
                         />
 
-                        <AnimatePresence>
-                            {errorBoxes}
-                        </AnimatePresence>
+                        <div className='max-h-96 overflow-y-auto'>
+                            <AnimatePresence>
+                                {errorBoxes}
+                            </AnimatePresence>
+                        </div>
 
 
                         {/* Example error message boxes commented out */}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -121,7 +121,7 @@ function App() {
         <div className={useDarkMode ? 'dark' : ''}>
             <NodeView />
             <div className='flex flex-row h-screen text-center'>
-                <div>
+                <div className='flex flex-col'>
                     <FloatingPanel heightPolicy='min' style={{ width: '300px' }}>
                         <DetailsBox
                             selection={selectedObjects}
@@ -195,7 +195,7 @@ function App() {
                         </div>
                     </FloatingPanel>
                 </div>
-                <div>
+                <div className='flex flex-col'>
                     <FloatingPanel heightPolicy='min' style={{ width: '250px' }}>
                         <DetailsBox_ActionStackViewer />
                     </FloatingPanel>


### PR DESCRIPTION
Putting each floating panel into a flex column container and ensuring y-axis overflow handling solves this bug. I also included y-axis overflow handling for the error boxes inside the currently selected node details box. This way, the user doesn't have to scroll through a potentially large amount of error messages to change the state details or to test a string. This PR addresses issue #96 