### PR TITLE
Add Fit Automaton on Screen button to Toolbox

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -276,7 +276,7 @@ export default class StateManager {
 
 
     //diagram bounds to know which exact part of the canvas to export
-    private static getDiagramBounds() {
+    private static getDiagramBounds(leftPadding=150, bottomPadding=150, rightPadding=150, topPadding=150) {
         if (!StateManager._nodeWrappers.length && !StateManager._transitionWrappers.length) {
             return { x: 0, y: 0, width: 0, height: 0 };
         }
@@ -291,11 +291,10 @@ export default class StateManager {
             maxY = Math.max(maxY, y + radius);
         });
 
-        const padding = 150;
-        minX -= padding;
-        minY -= padding;
-        maxX += padding;
-        maxY += padding;
+        minX -= leftPadding;
+        minY -= bottomPadding;
+        maxX += rightPadding;
+        maxY += topPadding;
         return {
             x: minX,
             y: minY,
@@ -1560,6 +1559,28 @@ export default class StateManager {
         const scaleBy = 0.9;  // Decrease scale by 10%
         StateManager.applyZoom(scaleBy);
     }
+    
+    /**
+     * Finds the bounding box of the automaton
+     * and scrolls/zooms the screen to it
+     */
+        public static fitAutomatonOnScreen() {
+            const bounds = StateManager.getDiagramBounds(StateManager._stage.width()/3, 50, 50, 50);
+            // Based on window size, the smaller scalar is what we need to be scale the zoom by, and then add some padding
+
+            let scale = Math.min(StateManager._stage.width() / bounds.width, StateManager._stage.height() / bounds.height);
+            const boxCenterX = bounds.x + bounds.width / 2;
+            const boxCenterY = bounds.y + bounds.height / 2;
+            // finally, apply the zoom and center it in the center of the bounding box
+            StateManager._stage.scale({ x: scale, y: scale });
+            StateManager._stage.position({
+                x: (StateManager._stage.width() / 2) - (boxCenterX * scale),
+                y: (StateManager._stage.height() / 2) - (boxCenterY * scale)
+            });
+            StateManager._stage.batchDraw();
+            StateManager.drawGrid();
+        }
+
     /**
      * Clear out the automaton and alphabet
      * then reset state ID to 0

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -276,7 +276,7 @@ export default class StateManager {
 
 
     //diagram bounds to know which exact part of the canvas to export
-    private static getDiagramBounds(leftPadding=150, bottomPadding=150, rightPadding=150, topPadding=150) {
+    private static getDiagramBounds(leftPadding: number = 150, bottomPadding: number = 150, rightPadding: number = 150, topPadding: number = 150) {
         if (!StateManager._nodeWrappers.length && !StateManager._transitionWrappers.length) {
             return { x: 0, y: 0, width: 0, height: 0 };
         }
@@ -1564,22 +1564,22 @@ export default class StateManager {
      * Finds the bounding box of the automaton
      * and scrolls/zooms the screen to it
      */
-        public static fitAutomatonOnScreen() {
-            const bounds = StateManager.getDiagramBounds(StateManager._stage.width()/3, 50, 50, 50);
-            // Based on window size, the smaller scalar is what we need to be scale the zoom by, and then add some padding
+    public static fitAutomatonOnScreen() {
+        const bounds = StateManager.getDiagramBounds(StateManager._stage.width()/3, 50, 50, 50);
+        // Based on window size, the smaller scalar is what we need to be scale the zoom by, and then add some padding
 
-            let scale = Math.min(StateManager._stage.width() / bounds.width, StateManager._stage.height() / bounds.height);
-            const boxCenterX = bounds.x + bounds.width / 2;
-            const boxCenterY = bounds.y + bounds.height / 2;
-            // finally, apply the zoom and center it in the center of the bounding box
-            StateManager._stage.scale({ x: scale, y: scale });
-            StateManager._stage.position({
-                x: (StateManager._stage.width() / 2) - (boxCenterX * scale),
-                y: (StateManager._stage.height() / 2) - (boxCenterY * scale)
-            });
-            StateManager._stage.batchDraw();
-            StateManager.drawGrid();
-        }
+        let scale = Math.min(StateManager._stage.width() / bounds.width, StateManager._stage.height() / bounds.height);
+        const boxCenterX = bounds.x + bounds.width / 2;
+        const boxCenterY = bounds.y + bounds.height / 2;
+        // finally, apply the zoom and center it in the center of the bounding box
+        StateManager._stage.scale({ x: scale, y: scale });
+        StateManager._stage.position({
+            x: (StateManager._stage.width() / 2) - (boxCenterX * scale),
+            y: (StateManager._stage.height() / 2) - (boxCenterY * scale)
+        });
+        StateManager._stage.batchDraw();
+        StateManager.drawGrid();
+    }
 
     /**
      * Clear out the automaton and alphabet

--- a/src/components/Toolbox.tsx
+++ b/src/components/Toolbox.tsx
@@ -9,6 +9,7 @@ import { GrGrid } from "react-icons/gr";
 import ConfirmationDialog from './ConfirmationDialog';
 import { FaRegImage } from "react-icons/fa6";
 import { BiFileBlank, BiReset} from "react-icons/bi";
+import { MdOutlineFitScreen } from "react-icons/md";
 
 import { ClosableModalWindow } from './ModalWindow';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -96,6 +97,8 @@ export default function Toolbox(props: React.PropsWithChildren<ToolboxProps>) {
             <ActionButton onClick={handleLoadButtonClick} icon={<BsUpload />} title="Load from JSON" bgColor="bg-amber-500"></ActionButton>
             {/* Reset Zoom Button */}
             <ActionButton onClick={StateManager.resetZoom} icon={<TbZoomReset />} title="Reset Zoom" bgColor="bg-blue-500"></ActionButton>
+            {/* Fit Automaton on Screen Button */}
+            <ActionButton onClick={StateManager.fitAutomatonOnScreen} icon={<MdOutlineFitScreen />} title="Fit Automaton on Screen" bgColor="bg-blue-500"></ActionButton>
             {/* Center Stage Button */}
             <ActionButton onClick={StateManager.centerStage} icon={<BiReset />} title="Center Stage" bgColor="bg-green-500"></ActionButton>
             {/* Zoom In Button */}


### PR DESCRIPTION
Fixes #61 

Currently leaves room for editing the bounds once we've finalized where the toolbox and action stack will permanently reside-- right now it adds 1/3 the screen as padding on the left to generally put things in actual usable view, but can be changed to whatever is best by changing the argument in the getDiagramBounds function call.