### PR TITLE
Multi node select UI

### DIFF
--- a/src/components/DetailsBox/DetailsBox.tsx
+++ b/src/components/DetailsBox/DetailsBox.tsx
@@ -22,22 +22,30 @@ interface DetailsBoxProps {
  * @returns
  */
 export default function DetailsBox(props: DetailsBoxProps) {
-  // For each item selected display its corresponding editor
-  const selectionElements = props.selection.map((item, index) => {
-    if (item instanceof NodeWrapper) {
-      return (
-        <DetailsBox_StateSelection
-          key={item.id}
-          nodeWrapper={item}
-          startNode={props.startNode}
-          setStartNode={props.setStartNode}
-        />
-      );
-    } else if (item instanceof TransitionWrapper) {
+  // seperate the selection into two, nodes and transitions
+  const selectedNodes = props.selection.filter(item => item instanceof NodeWrapper) as NodeWrapper[];
+  const selectedTransitions = props.selection.filter(item => item instanceof TransitionWrapper) as TransitionWrapper[];
+
+  // display a transition editor for each selected transition
+  let selectionElements = selectedTransitions.map((item, index) => {
+    if (item instanceof TransitionWrapper) {
       return <DetailsBox_TransitionSelection key={item.id} transition={item} />;
     }
     return <div key={`unhandled-${index}`}>Unhandled item type</div>;
   });
+
+  // display a node editor if at least node is selected
+  if (selectedNodes.length > 0) {
+    const combinedKey = selectedNodes.map(node => node.id).join('-');
+    selectionElements.unshift(
+      <DetailsBox_StateSelection
+        key={combinedKey}
+        nodeWrappers={selectedNodes}
+        startNode={props.startNode}
+        setStartNode={props.setStartNode}
+      />
+    )
+  }
 
   return (
     <div className="details-box flex flex-col h-min">

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -6,13 +6,13 @@ import { useActionStack } from "../../utilities/ActionStackUtilities";
 import { CoreListItem, CoreListItem_Left, ListItem } from "../ListItem";
 
 interface DetailsBox_StateSelectionProps {
-  nodeWrapper: NodeWrapper;
+  nodeWrappers: NodeWrapper[];
   startNode: NodeWrapper;
   setStartNode: React.Dispatch<React.SetStateAction<NodeWrapper>>;
 }
 
 /**
- * Creates the UI for modifying a node, including its label, whether it is an
+ * Creates the UI for modifying one or more nodes, including its label, whether it is an
  * accepting node, and whether it is the designated start node.
  * @param props
  * @param {NodeWrapper} props.nodeWrapper The node that this editor will modify.
@@ -21,32 +21,38 @@ interface DetailsBox_StateSelectionProps {
  * A function for setting the start node.
  * @returns
  */
-export default function DetailsBox_StateSelection(
-  props: DetailsBox_StateSelectionProps,
-) {
-  const nw = props.nodeWrapper;
-  const [nodeLabelText, setLabelText] = useState(nw.labelText);
-  const [isAcceptNode, setIsAcceptNode] = useState(nw.isAcceptNode);
-  const [isStartNodeInternal, setIsStartNodeInternal] = useState(
-    StateManager.startNode === nw,
-  );
+export default function DetailsBox_StateSelection(props: DetailsBox_StateSelectionProps) {
+    const { nodeWrappers, startNode, setStartNode } = props;
 
-  let updateNodeName = (newName: string) => {
-    setLabelText(newName);
-    StateManager.setNodeName(nw, newName);
-  };
+    const nw1 = nodeWrappers[0];
 
-  let updateNodeIsAccept = (isAccept: boolean) => {
-    setIsAcceptNode(isAccept);
-    StateManager.setNodeIsAccept(nw, isAccept);
-  };
+    const isMultiSelection = nodeWrappers.length > 1;
+    const allAccept = nodeWrappers.every(node => node.isAcceptNode);
+    const noneAccept = nodeWrappers.every(node => !node.isAcceptNode);
 
-  const [_, currentStackLocation] = useActionStack();
-  useEffect(() => {
-    setLabelText(nw.labelText);
-    setIsAcceptNode(nw.isAcceptNode);
-    setIsStartNodeInternal(StateManager.startNode === nw);
-  }, [currentStackLocation]);
+    const [nodeLabelText, setLabelText] = useState(nw1.labelText);
+    const [isAccept, setIsAccept] = useState(noneAccept ? false : (allAccept || undefined));
+    const [isStartNodeInternal, setIsStartNodeInternal] = useState(StateManager.startNode === nw1);
+
+    let updateNodeName = (newName: string) => {
+        setLabelText(newName);
+        StateManager.setNodeName(nw1, newName);
+    };
+
+    let updateNodeIsAccept = (isAccept: boolean) => {
+        setIsAccept(isAccept);
+        nodeWrappers.forEach(node => {
+            if (node.isAcceptNode !== isAccept)
+                StateManager.setNodeIsAccept(node, isAccept)
+        });
+    };
+
+    const [_, currentStackLocation] = useActionStack();
+    useEffect(() => {
+        setLabelText(nw1.labelText);
+        setIsAccept(noneAccept ? false : (allAccept || undefined));
+        setIsStartNodeInternal(StateManager.startNode === nw1);
+    }, [currentStackLocation]);
 
   let nodeNameInput = (
     <input
@@ -57,40 +63,37 @@ export default function DetailsBox_StateSelection(
       onChange={(e) => updateNodeName(e.target.value)}
     ></input>
   );
+    let nodeAcceptInput = (
+        <input
+            type="checkbox"
+            id="is-accept-state"
+            name="is-accept-state"
+            checked={isAccept}
+            ref={input => {
+                if (input) {
+                    input.indeterminate = isAccept === undefined;
+                }
+            }}
+            onChange={e => updateNodeIsAccept(e.target.checked)}></input>
+    );
 
-  let nodeAcceptInput = (
-    <input
-      type="checkbox"
-      id="is-accept-state"
-      name="is-accept-state"
-      checked={isAcceptNode}
-      onChange={(e) => updateNodeIsAccept(e.target.checked)}
-    ></input>
-  );
-
-  let startStateClasses = `${isStartNodeInternal ? "text-gray-700 dark:text-gray-300" : "text-blue-500 dark:text-blue-400 "} flex flex-row items-center`;
-  return (
-    <div className="flex flex-col">
-      <div className="font-medium text-2xl mb-2">State</div>
-      <div className="divide-y mb-3">
-        <ListItem title="Name" rightContent={nodeNameInput} />
-        <ListItem title="Accepts" rightContent={nodeAcceptInput} />
-      </div>
-      <div className="divide-y mb-3">
-        <CoreListItem>
-          <CoreListItem_Left>
-            <button
-              className={startStateClasses}
-              onClick={(_) => StateManager.setNodeIsStart(nw)}
-              disabled={isStartNodeInternal}
-            >
-              {isStartNodeInternal
-                ? "Current Start State"
-                : "Set As Start State"}
-            </button>
-          </CoreListItem_Left>
-        </CoreListItem>
-      </div>
-    </div>
-  );
+    let startStateClasses = `${isStartNodeInternal ? 'text-gray-700 dark:text-gray-300' : 'text-blue-500 dark:text-blue-400 '} flex flex-row items-center`
+    return (
+        <div className="flex flex-col">
+            <div className="font-medium text-2xl mb-2">State</div>
+            <div className="divide-y mb-3">
+                {!isMultiSelection && <ListItem title="Name" rightContent={nodeNameInput} />}
+                <ListItem title="Accepts" rightContent={nodeAcceptInput} />
+            </div>
+            {!isMultiSelection && <div className="divide-y mb-3">
+                <CoreListItem>
+                    <CoreListItem_Left>
+                        <button className={startStateClasses} onClick={_ => StateManager.setNodeIsStart(nw1)} disabled={isStartNodeInternal}>
+                            {isStartNodeInternal ? 'Current Start State' : 'Set As Start State'}
+                        </button>
+                    </CoreListItem_Left>
+                </CoreListItem>
+            </div>}
+        </div>
+    );
 }

--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -22,37 +22,37 @@ interface DetailsBox_StateSelectionProps {
  * @returns
  */
 export default function DetailsBox_StateSelection(props: DetailsBox_StateSelectionProps) {
-    const { nodeWrappers, startNode, setStartNode } = props;
+  const { nodeWrappers, startNode, setStartNode } = props;
 
-    const nw1 = nodeWrappers[0];
+  const nw1 = nodeWrappers[0];
 
-    const isMultiSelection = nodeWrappers.length > 1;
-    const allAccept = nodeWrappers.every(node => node.isAcceptNode);
-    const noneAccept = nodeWrappers.every(node => !node.isAcceptNode);
+  const isMultiSelection = nodeWrappers.length > 1;
+  const allAccept = nodeWrappers.every(node => node.isAcceptNode);
+  const noneAccept = nodeWrappers.every(node => !node.isAcceptNode);
 
-    const [nodeLabelText, setLabelText] = useState(nw1.labelText);
-    const [isAccept, setIsAccept] = useState(noneAccept ? false : (allAccept || undefined));
-    const [isStartNodeInternal, setIsStartNodeInternal] = useState(StateManager.startNode === nw1);
+  const [nodeLabelText, setLabelText] = useState(nw1.labelText);
+  const [isAccept, setIsAccept] = useState(noneAccept ? false : (allAccept || undefined));
+  const [isStartNodeInternal, setIsStartNodeInternal] = useState(StateManager.startNode === nw1);
 
-    let updateNodeName = (newName: string) => {
-        setLabelText(newName);
-        StateManager.setNodeName(nw1, newName);
-    };
+  let updateNodeName = (newName: string) => {
+    setLabelText(newName);
+    StateManager.setNodeName(nw1, newName);
+  };
 
-    let updateNodeIsAccept = (isAccept: boolean) => {
-        setIsAccept(isAccept);
-        nodeWrappers.forEach(node => {
-            if (node.isAcceptNode !== isAccept)
-                StateManager.setNodeIsAccept(node, isAccept)
-        });
-    };
+  let updateNodeIsAccept = (isAccept: boolean) => {
+    setIsAccept(isAccept);
+    nodeWrappers.forEach(node => {
+      if (node.isAcceptNode !== isAccept)
+        StateManager.setNodeIsAccept(node, isAccept)
+    });
+  };
 
-    const [_, currentStackLocation] = useActionStack();
-    useEffect(() => {
-        setLabelText(nw1.labelText);
-        setIsAccept(noneAccept ? false : (allAccept || undefined));
-        setIsStartNodeInternal(StateManager.startNode === nw1);
-    }, [currentStackLocation]);
+  const [_, currentStackLocation] = useActionStack();
+  useEffect(() => {
+    setLabelText(nw1.labelText);
+    setIsAccept(noneAccept ? false : (allAccept || undefined));
+    setIsStartNodeInternal(StateManager.startNode === nw1);
+  }, [currentStackLocation]);
 
   let nodeNameInput = (
     <input
@@ -60,40 +60,39 @@ export default function DetailsBox_StateSelection(props: DetailsBox_StateSelecti
       type="text"
       placeholder="State name"
       value={nodeLabelText}
-      onChange={(e) => updateNodeName(e.target.value)}
-    ></input>
+      onChange={(e) => updateNodeName(e.target.value)}></input>
   );
-    let nodeAcceptInput = (
-        <input
-            type="checkbox"
-            id="is-accept-state"
-            name="is-accept-state"
-            checked={isAccept}
-            ref={input => {
-                if (input) {
-                    input.indeterminate = isAccept === undefined;
-                }
-            }}
-            onChange={e => updateNodeIsAccept(e.target.checked)}></input>
-    );
+  let nodeAcceptInput = (
+    <input
+      type="checkbox"
+      id="is-accept-state"
+      name="is-accept-state"
+      checked={isAccept}
+      ref={input => {
+        if (input) {
+          input.indeterminate = isAccept === undefined;
+        }
+      }}
+      onChange={e => updateNodeIsAccept(e.target.checked)}></input>
+  );
 
-    let startStateClasses = `${isStartNodeInternal ? 'text-gray-700 dark:text-gray-300' : 'text-blue-500 dark:text-blue-400 '} flex flex-row items-center`
-    return (
-        <div className="flex flex-col">
-            <div className="font-medium text-2xl mb-2">State</div>
-            <div className="divide-y mb-3">
-                {!isMultiSelection && <ListItem title="Name" rightContent={nodeNameInput} />}
-                <ListItem title="Accepts" rightContent={nodeAcceptInput} />
-            </div>
-            {!isMultiSelection && <div className="divide-y mb-3">
-                <CoreListItem>
-                    <CoreListItem_Left>
-                        <button className={startStateClasses} onClick={_ => StateManager.setNodeIsStart(nw1)} disabled={isStartNodeInternal}>
-                            {isStartNodeInternal ? 'Current Start State' : 'Set As Start State'}
-                        </button>
-                    </CoreListItem_Left>
-                </CoreListItem>
-            </div>}
-        </div>
-    );
+  let startStateClasses = `${isStartNodeInternal ? 'text-gray-700 dark:text-gray-300' : 'text-blue-500 dark:text-blue-400 '} flex flex-row items-center`
+  return (
+    <div className="flex flex-col">
+      <div className="font-medium text-2xl mb-2">State</div>
+      <div className="divide-y mb-3">
+        {!isMultiSelection && <ListItem title="Name" rightContent={nodeNameInput} />}
+        <ListItem title="Accepts" rightContent={nodeAcceptInput} />
+      </div>
+      {!isMultiSelection && <div className="divide-y mb-3">
+        <CoreListItem>
+          <CoreListItem_Left>
+            <button className={startStateClasses} onClick={_ => StateManager.setNodeIsStart(nw1)} disabled={isStartNodeInternal}>
+              {isStartNodeInternal ? 'Current Start State' : 'Set As Start State'}
+            </button>
+          </CoreListItem_Left>
+        </CoreListItem>
+      </div>}
+    </div>
+  );
 }


### PR DESCRIPTION
Closes #106 .

This PR solves issue #106. I made the Name and SetAsStartState UI tabs disappear as discussed in our meeting. There was a couple issues that we talk about that would be good to add.

- Modify the current state selection UI to provide the name on the top where “state” currently is (multiple names go here for multi selections).
- Only one action should be added when setting multiple accept states at once.
