### PR TITLE
Fix transitions being removed on node deletion

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1629,9 +1629,7 @@ export default class StateManager {
     });
 
     StateManager._transitionWrappers = StateManager._transitionWrappers.filter(
-      (i) => {
-        !transitionsDependentOnDeletedNode.includes(i);
-      },
+      (i) => !transitionsDependentOnDeletedNode.includes(i),
     );
 
     StateManager._nodeWrappers = StateManager._nodeWrappers.filter(


### PR DESCRIPTION
This PR addresses issues #169 and #170. Turns out both of these issues where the same bug: when a node gets deleted using the deleteNode function, all transitions are also removed. The reason it wasn't obvious is because the UI didn't reflect the change (other than the UI error messages indicating something fishy going on).