### PR TITLE
Add "development" mode to webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,11 @@ const path = require("path");
 
 module.exports = {
   entry: "./src/index.tsx",
-  devtool: "inline-source-map",
+  // Once this is ready for release, swap the commented and uncommented portions of the next two lines.
+  mode: "development",
+  devtool: "eval-cheap-module-source-map",
+  // mode: "production",
+  // devtool: false,
   module: {
     rules: [
       {


### PR DESCRIPTION
This suppresses warnings intended for production releases.

Fixes #66 