### PR TITLE
generate error for duplicate tokens in alphabet

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1806,6 +1806,15 @@ export default class StateManager {
     return labels.length === uniqueLabels.size;
   }
 
+  /* Returns whether or not all tokens in the alphabet are unique */
+  public static areAllTokensUnique(): boolean {
+    const tokenSymbols = StateManager._alphabet.map((token) =>
+      token.symbol.trim(),
+    );
+    const uniqueSymbols = new Set(tokenSymbols);
+    return uniqueSymbols.size === tokenSymbols.length;
+  }
+
   /** Sets the array of tokens for the automaton. */
   public static set alphabet(newAlphabet: Array<TokenWrapper>) {
     StateManager._alphabet = newAlphabet;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,7 @@ function App() {
   );
   const [startNode, setStartNode] = useState(StateManager.startNode);
   const [isLabelUnique, setIsLabelUnique] = useState(true);
+  const [areTokensUnique, setAreTokensUnique] = useState(true);
   const [_, currentStackLocation] = useActionStack();
 
   // Adds the "confirm close" modal when attempting to close the page.
@@ -123,12 +124,19 @@ function App() {
     (token) => token.symbol.trim() === "",
   );
 
-  // Keep track of if all tokens' labels are unique, every time the
+  // Keep track of if all state labels are unique, every time the
   // list of selected objects changes.
   useEffect(() => {
     const unique = StateManager.areAllLabelsUnique();
     setIsLabelUnique(unique);
   }, [selectedObjects]);
+
+  // Keep track of if all tokens' labels are unique, every time the
+  // list of selected objects changes.
+  useEffect(() => {
+    const unique = StateManager.areAllTokensUnique();
+    setAreTokensUnique(unique);
+  }, [StateManager.alphabet]);
 
   // React state and open/close functions for the "Configure Automaton"
   // modal window.
@@ -220,6 +228,11 @@ function App() {
             <InformationBox infoBoxType={InformationBoxType.Error}>
               Duplicate state labels detected. Each state must have a unique
               label.
+            </InformationBox>
+          )}
+          {!areTokensUnique && (
+            <InformationBox infoBoxType={InformationBoxType.Error}>
+              Duplicate tokens detected. Each token must be a unique character.
             </InformationBox>
           )}
           {emptyStringToken && (


### PR DESCRIPTION
when creating the alphabet, having two duplicate tokens generates an error similar to having an empty token. 