### PR TITLE
fix undo transition error

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1563,7 +1563,9 @@ export default class StateManager {
     removeData.nodes = selectedNodes;
     removeData.transitions = [
       ...selectedTransitions,
-      ...transitionsInvolvingSelectedNodes,
+      ...transitionsInvolvingSelectedNodes.filter(
+        (transition) => !selectedTransitions.includes(transition),
+      ),
     ];
 
     // Save start node if it's being removed


### PR DESCRIPTION
The issue was that we were adding  (selected transition + the transition we would get from deleting a node) to the array of things to delete, so we would get duplicate transitions. 