### PR TITLE
Fix accept state action stack

### DIFF
--- a/src/components/DetailsBox/DetailsBox_StateSelection.tsx
+++ b/src/components/DetailsBox/DetailsBox_StateSelection.tsx
@@ -47,10 +47,7 @@ export default function DetailsBox_StateSelection(
 
   let updateNodeIsAccept = (isAccept: boolean) => {
     setIsAccept(isAccept);
-    nodeWrappers.forEach((node) => {
-      if (node.isAcceptNode !== isAccept)
-        StateManager.setNodeIsAccept(node, isAccept);
-    });
+    StateManager.setNodesIsAccept(nodeWrappers, isAccept);
   };
 
   const [_, currentStackLocation] = useActionStack();


### PR DESCRIPTION
When selecting and setting multiple states to "accept", all changes should be batched in one action within the action stack. 