### PR TITLE
made it so the user no longer deselects items if they are holding shift

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -466,7 +466,7 @@ export default class StateManager {
     let thingUnderMouse = StateManager._stage.getIntersection(
       StateManager._stage.getPointerPosition(),
     );
-    if (!thingUnderMouse) {
+    if (!thingUnderMouse && !evt.evt.shiftKey) {
       StateManager.deselectAllObjects();
     }
   }

--- a/src/components/Toolbox.tsx
+++ b/src/components/Toolbox.tsx
@@ -79,9 +79,7 @@ export default function Toolbox(props: React.PropsWithChildren<ToolboxProps>) {
     StateManager.toggleSnapToGrid();
     setIsSnapActive(!isSnapActive); // Toggle the local UI state
   };
-  const [isDebugActive, setIsDebugActive] = useState(
-    StateManager.debugEnabled,
-  );
+  const [isDebugActive, setIsDebugActive] = useState(StateManager.debugEnabled);
   const handleToggleDebug = () => {
     StateManager.setDebug();
     setIsDebugActive(!isDebugActive);


### PR DESCRIPTION
This will make it less frustrating if you miss click when selecting a large set of nodes and transitions.