### PR TITLE
Made it so the text for input is always black and made the undo color be visible in both light and dark.

### DIFF
--- a/src/components/DetailsBox/DetailsBox_ActionStackViewer.tsx
+++ b/src/components/DetailsBox/DetailsBox_ActionStackViewer.tsx
@@ -23,7 +23,7 @@ interface ActionRowItemProps {
 function ActionRowItem(props: ActionRowItemProps) {
   return (
     <div
-      className={`border-t-2 border-zinc-400 ${props.greyedOut ? "text-slate-500" : ""}`}
+      className={`border-t-2 border-zinc-400 ${props.greyedOut ? "text-zinc-400" : ""}`}
     >
       {props.displayString}
     </div>

--- a/src/components/TestStringWindow.tsx
+++ b/src/components/TestStringWindow.tsx
@@ -47,7 +47,7 @@ export default function TestStringWindow() {
     <div>
       <div className="flex items-center bg-white p-3 rounded-lg shadow-sm border border-gray-300">
         <input
-          className="focus:outline-none bg-transparent flex-grow border-0 py-2"
+          className="focus:outline-none bg-transparent flex-grow border-0 py-2 text-black"
           type="text"
           placeholder="Enter string to test"
           value={testString}


### PR DESCRIPTION
I just changed the color for undo from slate-500 to zinc-400 like the border. you can now see it on both dark mode and light mode. I also set the text of the input box to always be black since its on a white background at all times.