### PR TITLE
Remember dark mode

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -265,9 +265,23 @@ export default class StateManager {
       StateManager.endResizeCommentOperation();
     });
 
+    if (this.storageAvailable()) {
+      if (localStorage.getItem("darkmode")) {
+        //console.log("darkmode was on...");
+        StateManager.useDarkMode = true;
+      } else {
+        //console.log("no darkmode detected");
+      }
+    }
+
     addEventListener("keydown", this.onKeyDown);
     addEventListener("resize", this.handleResize);
     StateManager.makeClean();
+  }
+
+  public static storageAvailable() {
+    console.log(typeof Storage.toString());
+    return typeof Storage != "undefined";
   }
 
   /** Gets the array of transitions for the automaton. */
@@ -2463,6 +2477,10 @@ export default class StateManager {
     StateManager.makeClean();
     // Save new value
     this._useDarkMode = val;
+    // Save value to storage
+    if (StateManager.storageAvailable()) {
+      localStorage.setItem("darkmode", val.toString());
+    }
 
     this._nodeWrappers.forEach((n) => n.updateColorScheme());
     this._transitionWrappers.forEach((t) => t.updateColorScheme());

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -265,22 +265,12 @@ export default class StateManager {
       StateManager.endResizeCommentOperation();
     });
 
-    if (this.storageAvailable()) {
-      if (localStorage.getItem("darkmode")) {
-        //console.log("darkmode was on...");
-        StateManager.useDarkMode = true;
-      } else {
-        //console.log("no darkmode detected");
-      }
-    }
-
     addEventListener("keydown", this.onKeyDown);
     addEventListener("resize", this.handleResize);
     StateManager.makeClean();
   }
 
   public static storageAvailable() {
-    console.log(typeof Storage.toString());
     return typeof Storage != "undefined";
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ import { useActionStack } from "./utilities/ActionStackUtilities";
 import { GrTest } from "react-icons/gr";
 import TestCasesPanel from "./components/TestCasesPanel";
 
-function App() {
+function App({ defaultDarkMode }: { defaultDarkMode: boolean }) {
   const [currentTool, setCurrentTool] = useState(Tool.States);
   const [selectedObjects, setSelectedObjects] = useState(
     new Array<SelectableObject>(),
@@ -159,7 +159,7 @@ function App() {
   };
 
   // React state and enable/disable functions for dark mode.
-  const [useDarkMode, setDarkMode] = useState(false);
+  const [useDarkMode, setDarkMode] = useState(defaultDarkMode);
   const toggleDarkMode = () => {
     setDarkMode(!useDarkMode);
   };
@@ -312,6 +312,15 @@ function App() {
   );
 }
 
+// If the browser has storage available, and the user has saved their
+// dark mode preference, then use that by default.
+let defaultDarkMode = false;
+if (StateManager.storageAvailable()) {
+  if (localStorage.getItem("darkmode") == "true") {
+    defaultDarkMode = true;
+  }
+}
+
 const domNode = document.getElementById("react-root");
 const root = createRoot(domNode);
-root.render(<App />);
+root.render(<App defaultDarkMode={defaultDarkMode} />);


### PR DESCRIPTION
Closes #190. Closes #209.

This PR allows browsers to save the user's dark mode setting so that when they next open the page, their preferred setting appears by default.
