### PR TITLE
Allow user to enter multiple tokens at a time

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1465,20 +1465,20 @@ export default class StateManager {
       }
 
       // Check if the symbol already exists
-      if (StateManager._alphabet.some(token => token.symbol === newSymbol)) {
+      if (StateManager._alphabet.some((token) => token.symbol === newSymbol)) {
         continue;
       }
       const newToken = new TokenWrapper();
       const oldSymbol = newToken.symbol;
-      
+
       tokensData.push({
         token: newToken,
         oldSymbol: oldSymbol,
-        newSymbol: newSymbol
+        newSymbol: newSymbol,
       });
     }
   }
-  
+
   /**
    * Pushes an action to the action stack that removes the given token from
    * the automaton.

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1448,6 +1448,38 @@ export default class StateManager {
   }
 
   /**
+   * Pushes an action to the action stack that adds an array of new tokens
+   * with symbols to the automaton.
+   */
+  public static addTokensWithSymbols(newSymbols: string[]) {
+    // TODO: logic for removing tokens needs to be modified - right now
+    // it looks like it does some checks that we may no longer want, now
+    // that we have undo/redo!
+    const tokensData: addTokensWithSymbolsActionData[] = [];
+
+    for (let i = 0; i < newSymbols.length; i++) {
+      const newSymbol = newSymbols[i];
+      // Check if the symbol is empty
+      if (newSymbol == "") {
+        continue;
+      }
+
+      // Check if the symbol already exists
+      if (StateManager._alphabet.some(token => token.symbol === newSymbol)) {
+        continue;
+      }
+      const newToken = new TokenWrapper();
+      const oldSymbol = newToken.symbol;
+      
+      tokensData.push({
+        token: newToken,
+        oldSymbol: oldSymbol,
+        newSymbol: newSymbol
+      });
+    }
+  }
+  
+  /**
    * Pushes an action to the action stack that removes the given token from
    * the automaton.
    * @param token The token to remove.
@@ -2876,6 +2908,18 @@ class SetTransitionAcceptsTokenData extends ActionData {
 class AddTokenActionData extends ActionData {
   /** The token created in this action. */
   public token: TokenWrapper;
+}
+
+/** Holds the data associated with an "add tokens with symbols to automaton" action. */
+class addTokensWithSymbolsActionData extends ActionData {
+  /** The token created in this action. */
+  public token: TokenWrapper;
+
+  /** The symbol for this token before this action. */
+  public oldSymbol: string;
+
+  /** The symbol for this token after this action. */
+  public newSymbol: string;
 }
 
 /** Holds the data associated with a "remove token from automaton" action. */

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1452,15 +1452,14 @@ export default class StateManager {
    * with symbols to the automaton.
    */
   public static addTokensWithSymbols(newSymbols: string[]) {
-    // TODO: logic for removing tokens needs to be modified - right now
-    // it looks like it does some checks that we may no longer want, now
-    // that we have undo/redo!
+    // Clear TODO: logic for removing tokens is now handled with undo/redo actions
     const tokensData: addTokensWithSymbolsActionData[] = [];
 
     for (let i = 0; i < newSymbols.length; i++) {
       const newSymbol = newSymbols[i];
+
       // Check if the symbol is empty
-      if (newSymbol == "") {
+      if (newSymbol === "") {
         continue;
       }
 
@@ -1468,14 +1467,36 @@ export default class StateManager {
       if (StateManager._alphabet.some((token) => token.symbol === newSymbol)) {
         continue;
       }
-      const newToken = new TokenWrapper();
-      const oldSymbol = newToken.symbol;
 
-      tokensData.push({
-        token: newToken,
-        oldSymbol: oldSymbol,
-        newSymbol: newSymbol,
-      });
+      // Create a new token and set its symbol
+      const newToken = new TokenWrapper();
+      newToken.symbol = newSymbol;
+
+      // Define forward and backward actions for undo/redo
+      let addTokenForward = (data: addTokensWithSymbolsActionData) => {
+        StateManager._alphabet.push(data.token);
+      };
+
+      let addTokenBackward = (data: addTokensWithSymbolsActionData) => {
+        StateManager._alphabet = StateManager._alphabet.filter(
+          (i) => i !== data.token,
+        );
+      };
+
+      // Create an action for adding the token
+      let addTokenAction = new Action(
+        "addToken",
+        `Add Token "${newSymbol}"`,
+        addTokenForward,
+        addTokenBackward,
+        { token: newToken, oldSymbol: "", newSymbol: newSymbol },
+      );
+
+      // Push the action to the undo/redo manager
+      UndoRedoManager.pushAction(addTokenAction);
+
+      // Add the token data to the tokensData array
+      tokensData.push({ token: newToken, oldSymbol: "", newSymbol: newSymbol });
     }
   }
 

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1448,13 +1448,11 @@ export default class StateManager {
   }
 
   /**
-   * Pushes an action to the action stack that adds an array of new tokens
-   * with symbols to the automaton.
+   * Pushes actions to the action stack that add new tokens with symbols to
+   * the automaton.
+   * @param newSymbols An array of symbols to create new tokens for.
    */
   public static addTokensWithSymbols(newSymbols: string[]) {
-    // Clear TODO: logic for removing tokens is now handled with undo/redo actions
-    const tokensData: addTokensWithSymbolsActionData[] = [];
-
     for (let i = 0; i < newSymbols.length; i++) {
       const newSymbol = newSymbols[i];
 
@@ -1473,11 +1471,11 @@ export default class StateManager {
       newToken.symbol = newSymbol;
 
       // Define forward and backward actions for undo/redo
-      let addTokenForward = (data: addTokensWithSymbolsActionData) => {
+      let addTokenForward = (data: AddTokenActionData) => {
         StateManager._alphabet.push(data.token);
       };
 
-      let addTokenBackward = (data: addTokensWithSymbolsActionData) => {
+      let addTokenBackward = (data: AddTokenActionData) => {
         StateManager._alphabet = StateManager._alphabet.filter(
           (i) => i !== data.token,
         );
@@ -1494,9 +1492,6 @@ export default class StateManager {
 
       // Push the action to the undo/redo manager
       UndoRedoManager.pushAction(addTokenAction);
-
-      // Add the token data to the tokensData array
-      tokensData.push({ token: newToken, oldSymbol: "", newSymbol: newSymbol });
     }
   }
 
@@ -2929,18 +2924,6 @@ class SetTransitionAcceptsTokenData extends ActionData {
 class AddTokenActionData extends ActionData {
   /** The token created in this action. */
   public token: TokenWrapper;
-}
-
-/** Holds the data associated with an "add tokens with symbols to automaton" action. */
-class addTokensWithSymbolsActionData extends ActionData {
-  /** The token created in this action. */
-  public token: TokenWrapper;
-
-  /** The symbol for this token before this action. */
-  public oldSymbol: string;
-
-  /** The symbol for this token after this action. */
-  public newSymbol: string;
 }
 
 /** Holds the data associated with a "remove token from automaton" action. */

--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -46,8 +46,7 @@ function ListItem_TokenEditor(
         <input
           className="focus:outline-none bg-transparent grow"
           type="text"
-          minLength={1}
-          maxLength={1}
+          onChange={(e) => updateTokenSymbol(e.target.value)}
           placeholder="Token symbol"
           value={tokenSymbol}
         ></input>
@@ -114,7 +113,7 @@ function AlphabetList() {
             <input
               className="focus:outline-none bg-transparent grow"
               type="text"
-              placeholder="q1,q2,q3"
+              placeholder="a,b,c"
               value={inputValue}
               onChange={handleChange}
               onKeyUp={handleKeyUp}

--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -76,14 +76,16 @@ function AlphabetList() {
   const [inputValue, setInputValue] = useState("");
 
   function addTokenToAlphabet() {
-    const newSymbols = new Set(inputValue.split(',').map(token => token.trim()));
+    const newSymbols = new Set(
+      inputValue.split(",").map((token) => token.trim()),
+    );
     const newSymbolsArray = Array.from(newSymbols);
     StateManager.addTokensWithSymbols(newSymbolsArray);
     setInputValue("");
   }
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === "Enter") {
       addTokenToAlphabet();
     }
   };

--- a/src/components/ConfigureAutomatonWindow.tsx
+++ b/src/components/ConfigureAutomatonWindow.tsx
@@ -50,7 +50,6 @@ function ListItem_TokenEditor(
           maxLength={1}
           placeholder="Token symbol"
           value={tokenSymbol}
-          onChange={(e) => updateTokenSymbol(e.target.value)}
         ></input>
       </CoreListItem_Left>
 
@@ -73,11 +72,25 @@ function ListItem_TokenEditor(
  * @returns
  */
 function AlphabetList() {
-  const [alphabet, setAlphabet] = useState(StateManager.alphabet);
+  const [alphabet, setAlphabet] = useState<TokenWrapper[]>([]);
+  const [inputValue, setInputValue] = useState("");
 
   function addTokenToAlphabet() {
-    StateManager.addToken();
+    const newSymbols = new Set(inputValue.split(',').map(token => token.trim()));
+    const newSymbolsArray = Array.from(newSymbols);
+    StateManager.addTokensWithSymbols(newSymbolsArray);
+    setInputValue("");
   }
+
+  const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      addTokenToAlphabet();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
 
   // Track the action stack's location so that any undo/redo commands will
   // update the UI to correctly reflect the current state.
@@ -94,18 +107,19 @@ function AlphabetList() {
     <>
       <div className="mt-3 ml-1 mb-1">Input Alphabet</div>
       <div className="divide-y">
-        {tokenWrapperElements}
         <CoreListItem>
           <CoreListItem_Left>
-            <button
-              className="text-blue-500 dark:text-blue-400 flex flex-row items-center"
-              onClick={addTokenToAlphabet}
-            >
-              <BsPlusCircleFill className="mr-1" />
-              Add Token
-            </button>
+            <input
+              className="focus:outline-none bg-transparent grow"
+              type="text"
+              placeholder="q1,q2,q3"
+              value={inputValue}
+              onChange={handleChange}
+              onKeyUp={handleKeyUp}
+            />
           </CoreListItem_Left>
         </CoreListItem>
+        {tokenWrapperElements}
       </div>
     </>
   );


### PR DESCRIPTION
Closes #140. Closes #185.

This PR changes the way the token entry box works. You can now type a comma-separated list of token names, and when the Enter key is pressed, all of them are added to the automaton at once.

Note that each token is added in a separate action stack operation. In the future, these should all be combined into a single operation.