### PR TITLE
Move action stack panel to right of window

### DIFF
--- a/src/components/FloatingPanel.tsx
+++ b/src/components/FloatingPanel.tsx
@@ -18,7 +18,7 @@ export default function FloatingPanel(
   props: React.PropsWithChildren<FloatingPanelProps>,
 ) {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col h-screen">
       <div
         className={`z-10 bg-gray-300/50 dark:bg-gray-300/50 dark:text-white w-fit h-${props.heightPolicy} p-2 m-5 rounded-lg backdrop-blur-xl shadow-xl overflow-y-auto`}
         style={props.style}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,7 +198,7 @@ function App({ defaultDarkMode }: { defaultDarkMode: boolean }) {
       <NodeView />
       <div className="flex flex-row h-screen text-center">
         <div className="overflow-y-auto">
-          <FloatingPanel heightPolicy="min" style={{ width: "300px" }}>
+          <FloatingPanel heightPolicy="screen" style={{ width: "300px" }}>
             <DetailsBox
               selection={selectedObjects}
               startNode={startNode}
@@ -286,12 +286,15 @@ function App({ defaultDarkMode }: { defaultDarkMode: boolean }) {
           {testsPanelOpen && <TestCasesPanel />}
         </div>
 
-        <FloatingPanel heightPolicy="min" style={{ width: "250px" }}>
-          <DetailsBox_ActionStackViewer />
+        <FloatingPanel heightPolicy="screen">
+          <Toolbox currentTool={currentTool} setCurrentTool={setCurrentTool} />
         </FloatingPanel>
 
-        <FloatingPanel heightPolicy="min">
-          <Toolbox currentTool={currentTool} setCurrentTool={setCurrentTool} />
+        {/*Separates the left and right panels */}
+        <div className="grow"></div>
+
+        <FloatingPanel heightPolicy="screen" style={{ width: "250px" }}>
+          <DetailsBox_ActionStackViewer />
         </FloatingPanel>
       </div>
       {


### PR DESCRIPTION
This PR places the Action Stack panel on the right hand side of the window, rather than stacking it on the left. This centers the working space better in the application.

<img width="2950" height="1926" alt="CleanShot 2025-09-10 at 20 39 51@2x" src="https://github.com/user-attachments/assets/2d6ad5a4-5050-4c27-a846-ab4ebd3b1f83" />
